### PR TITLE
Bugfix/issue 283

### DIFF
--- a/src/locales/en/translationEn.json
+++ b/src/locales/en/translationEn.json
@@ -279,7 +279,7 @@
           "changeToFree": "Change to free",
           "changeToPaid": "Change to paid",
           "changeToRegister": "Change to register",
-          "changeToFreeTooltip": "Use when your event is free of charge.",
+          "changeToFreeTooltip": "Use when your event is free of charge and does not require registration.",
           "changeToPaidTooltip": "Use when event is ticketed.",
           "changeToRegisterTooltip": "Use when event requires attendee sign up.",
           "price": "Price",

--- a/src/locales/fr/transalationFr.json
+++ b/src/locales/fr/transalationFr.json
@@ -277,7 +277,7 @@
           "changeToFree": "Changer pour gratuit",
           "changeToPaid": "Changer pour payant",
           "changeToRegister": "Changer pour inscription",
-          "changeToFreeTooltip": "À utiliser lorsque votre événement est gratuit.",
+          "changeToFreeTooltip": "À utiliser lorsque votre événement est gratuit et ne nécessite pas d'inscription.",
           "changeToPaidTooltip": "A utiliser lorsque l'événement est payant.",
           "changeToRegisterTooltip": "A utiliser lorsque l'événement nécessite l'inscription des participants.",
           "price": "Prix",

--- a/src/pages/Dashboard/EventReadOnly/EventReadOnly.jsx
+++ b/src/pages/Dashboard/EventReadOnly/EventReadOnly.jsx
@@ -37,6 +37,7 @@ import { pluralize } from '../../../utils/pluralise';
 import i18n from 'i18next';
 import { userRoles } from '../../../constants/userRoles';
 import { eventFormRequiredFieldNames } from '../../../constants/eventFormRequiredFieldNames';
+import { contentLanguage } from '../../../constants/contentLanguage';
 
 function EventReadOnly() {
   const { t } = useTranslation();
@@ -179,14 +180,18 @@ function EventReadOnly() {
                     </p>
                     {eventData?.name?.fr && (
                       <>
-                        <p className="read-only-event-content-sub-title-secondary">{t('common.tabFrench')}</p>
+                        {calendarContentLanguage === contentLanguage.BILINGUAL && (
+                          <p className="read-only-event-content-sub-title-secondary">{t('common.tabFrench')}</p>
+                        )}
                         <p className="read-only-event-content">{eventData?.name?.fr}</p>
                       </>
                     )}
 
                     {eventData?.name?.en && (
                       <>
-                        <p className="read-only-event-content-sub-title-secondary">{t('common.tabEnglish')}</p>
+                        {calendarContentLanguage === contentLanguage.BILINGUAL && (
+                          <p className="read-only-event-content-sub-title-secondary">{t('common.tabEnglish')}</p>
+                        )}
                         <p className="read-only-event-content">{eventData?.name?.en}</p>
                       </>
                     )}
@@ -500,13 +505,17 @@ function EventReadOnly() {
 
                     {initialVirtualLocation[0] && initialVirtualLocation[0]?.name.fr && (
                       <>
-                        <p className="read-only-event-content-sub-title-secondary">{t('common.tabFrench')}</p>
+                        {calendarContentLanguage === contentLanguage.BILINGUAL && (
+                          <p className="read-only-event-content-sub-title-secondary">{t('common.tabFrench')}</p>
+                        )}
                         <p className="read-only-event-content">{initialVirtualLocation[0]?.name.fr}</p>
                       </>
                     )}
                     {initialVirtualLocation[0] && initialVirtualLocation[0]?.name.en && (
                       <>
-                        <p className="read-only-event-content-sub-title-secondary">{t('common.tabEnglish')}</p>
+                        {calendarContentLanguage === contentLanguage.BILINGUAL && (
+                          <p className="read-only-event-content-sub-title-secondary">{t('common.tabEnglish')}</p>
+                        )}
                         <p className="read-only-event-content">{initialVirtualLocation[0]?.name.en}</p>
                       </>
                     )}
@@ -558,13 +567,17 @@ function EventReadOnly() {
                     )}
                     {eventData?.description?.fr && (
                       <>
-                        <p className="read-only-event-content-sub-title-secondary">{t('common.tabFrench')}</p>
+                        {calendarContentLanguage === contentLanguage.BILINGUAL && (
+                          <p className="read-only-event-content-sub-title-secondary">{t('common.tabFrench')}</p>
+                        )}
                         <div dangerouslySetInnerHTML={{ __html: eventData?.description?.fr }} />
                       </>
                     )}
                     {eventData?.description?.en && (
                       <>
-                        <p className="read-only-event-content-sub-title-secondary">{t('common.tabEnglish')}</p>
+                        {calendarContentLanguage === contentLanguage.BILINGUAL && (
+                          <p className="read-only-event-content-sub-title-secondary">{t('common.tabEnglish')}</p>
+                        )}
                         <div dangerouslySetInnerHTML={{ __html: eventData?.description?.en }} />
                       </>
                     )}
@@ -923,13 +936,17 @@ function EventReadOnly() {
                     )}
                     {eventData?.accessibilityNote?.fr && (
                       <>
-                        <p className="read-only-event-content-sub-title-secondary">{t('common.tabFrench')}</p>
+                        {calendarContentLanguage === contentLanguage.BILINGUAL && (
+                          <p className="read-only-event-content-sub-title-secondary">{t('common.tabFrench')}</p>
+                        )}
                         <p className="read-only-event-content">{eventData?.accessibilityNote?.fr}</p>
                       </>
                     )}
                     {eventData?.accessibilityNote?.en && (
                       <>
-                        <p className="read-only-event-content-sub-title-secondary">{t('common.tabEnglish')}</p>
+                        {calendarContentLanguage === contentLanguage.BILINGUAL && (
+                          <p className="read-only-event-content-sub-title-secondary">{t('common.tabEnglish')}</p>
+                        )}
                         <p className="read-only-event-content">{eventData?.accessibilityNote?.en}</p>
                       </>
                     )}
@@ -1033,13 +1050,17 @@ function EventReadOnly() {
                     )}
                     {eventData?.offerConfiguration?.name?.fr && (
                       <>
-                        <p className="read-only-event-content-sub-title-secondary">{t('common.tabFrench')}</p>
+                        {calendarContentLanguage === contentLanguage.BILINGUAL && (
+                          <p className="read-only-event-content-sub-title-secondary">{t('common.tabFrench')}</p>
+                        )}
                         <p className="read-only-event-content">{eventData?.offerConfiguration?.name?.fr}</p>
                       </>
                     )}
                     {eventData?.offerConfiguration?.name?.en && (
                       <>
-                        <p className="read-only-event-content-sub-title-secondary">{t('common.tabEnglish')}</p>
+                        {calendarContentLanguage === contentLanguage.BILINGUAL && (
+                          <p className="read-only-event-content-sub-title-secondary">{t('common.tabEnglish')}</p>
+                        )}
                         <p className="read-only-event-content">{eventData?.offerConfiguration?.name?.en}</p>
                       </>
                     )}


### PR DESCRIPTION
1.In unilingual cms on read only pages: please remove French (or English) subtitles from fields that can be bilingual.
2.This second request comes from our clients to update the informaton text for free events - they want their contributors to be very clear on when to choose free vs registration for events that are free AND require registration