### PR TITLE
fix: added space before postal code in places selection item component

### DIFF
--- a/src/components/List/SelectionItem/SelectionItem.jsx
+++ b/src/components/List/SelectionItem/SelectionItem.jsx
@@ -76,7 +76,7 @@ function SelectionItem(props) {
                             interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
                             calendarContentLanguage: calendarContentLanguage,
                           })}
-                          ,
+                          ,&nbsp;
                         </span>
                       )}
                       <br />
@@ -99,6 +99,7 @@ function SelectionItem(props) {
                             interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
                             calendarContentLanguage: calendarContentLanguage,
                           })}
+                          &nbsp;
                         </span>
                       )}
 


### PR DESCRIPTION
https://github.com/culturecreates/footlight-app/issues/265#issuecomment-1523377050