### PR TITLE
fix: added height ,width and image type to image property while saving an event

### DIFF
--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -506,6 +506,9 @@ function AddEvent() {
               if (values?.dragger && values?.dragger?.length == 0) eventObj['image'] = null;
               else
                 eventObj['image'] = {
+                  height: eventData?.image?.height,
+                  type: eventData?.image?.type,
+                  width: eventData?.image?.width,
                   large: {
                     entityId: eventData?.image?.large?.entityId,
                   },


### PR DESCRIPTION
[…](https://github.com/culturecreates/footlight-app/issues/308)