### PR TITLE
Update build-staging-deploy-s3.yml

### DIFF
--- a/.github/workflows/build-staging-deploy-s3.yml
+++ b/.github/workflows/build-staging-deploy-s3.yml
@@ -12,7 +12,8 @@ jobs:
     - uses: actions/checkout@v2
     - run: npm install
     - run: npm run build:staging
-    - run: aws s3 sync ./build s3://staging.cms.footlight.io/ --acl public-read --delete
+    - run: aws s3 sync ./build s3://staging.cms.footlight.io/ --acl public-read --delete  --exclude build/index.html
+    - run: aws s3 cp build/index.html s3://staging.cms.footlight.io/index.html --metadata-directive REPLACE --cache-control max-age=0,s-maxage=86400 --acl public-read --content-type text/html
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Added copy on index.html so we can set headers for --cache-control including browser controls to not cache (max-age) and Cloud Front CDN controls to cache for 1 day (s-maxage). We want the browser to always check with Cloud Front for the lastest index.html with cache busting names baked into the js and css files. When new code is deployed to Cloud Front there is an invalidation run to clear Cloud Front.