### PR TITLE
fix: role based check to search page routing added

### DIFF
--- a/src/pages/Dashboard/SearchOrganizations/SearchOrganizations.jsx
+++ b/src/pages/Dashboard/SearchOrganizations/SearchOrganizations.jsx
@@ -18,6 +18,7 @@ import { PathName } from '../../../constants/pathName';
 import { artsDataDuplicateFilter } from '../../../utils/artsDataEntityFilter';
 import { Popover } from 'antd';
 import { getArtsDataEntities } from '../../../services/artsData';
+import { routinghandler } from '../../../utils/roleRoutingHandler';
 
 function SearchOrganizations() {
   const { t } = useTranslation();
@@ -128,11 +129,14 @@ function SearchOrganizations() {
                           artsDataLink={artsDataLinkChecker(organizer?.uri)}
                           Logo={organizer.logo ? <img src={organizer.logo?.thumbnail?.uri} /> : <Logo />}
                           linkText={t('dashboard.organization.createNew.search.linkText')}
-                          onClick={() =>
-                            navigate(
-                              `${PathName.Dashboard}/${calendarId}${PathName.Organizations}${PathName.AddOrganization}?id=${organizer?.id}`,
-                            )
-                          }
+                          onClick={() => {
+                            if (routinghandler(user, calendarId, organizer?.creator?.userId, null, true)) {
+                              navigate(
+                                `${PathName.Dashboard}/${calendarId}${PathName.Organizations}${PathName.AddOrganization}?id=${organizer?.id}`,
+                              );
+                            } else
+                              navigate(`${PathName.Dashboard}/${calendarId}${PathName.Organizations}/${organizer?.id}`);
+                          }}
                         />
                       </div>
                     ))

--- a/src/pages/Dashboard/SearchPerson/SearchPerson.jsx
+++ b/src/pages/Dashboard/SearchPerson/SearchPerson.jsx
@@ -17,6 +17,7 @@ import { UserOutlined } from '@ant-design/icons';
 import { contentLanguageBilingual } from '../../../utils/bilingual';
 import './searchPerson.css';
 import { getArtsDataEntities } from '../../../services/artsData';
+import { routinghandler } from '../../../utils/roleRoutingHandler';
 
 function SearchPerson() {
   const { t } = useTranslation();
@@ -131,11 +132,13 @@ function SearchPerson() {
                           )
                         }
                         linkText={t('dashboard.people.createNew.search.linkText')}
-                        onClick={() =>
-                          navigate(
-                            `${PathName.Dashboard}/${calendarId}${PathName.People}${PathName.AddPerson}?id=${person?.id}`,
-                          )
-                        }
+                        onClick={() => {
+                          if (routinghandler(user, calendarId, person?.creator?.userId, null, true)) {
+                            navigate(
+                              `${PathName.Dashboard}/${calendarId}${PathName.People}${PathName.AddPerson}?id=${person?.id}`,
+                            );
+                          } else navigate(`${PathName.Dashboard}/${calendarId}${PathName.People}/${person?.id}`);
+                        }}
                       />
                     </div>
                   ))

--- a/src/pages/Dashboard/SearchPlaces/SearchPlaces.jsx
+++ b/src/pages/Dashboard/SearchPlaces/SearchPlaces.jsx
@@ -17,6 +17,7 @@ import './searchPlaces.css';
 import { entitiesClass } from '../../../constants/entitiesClass';
 import { useGetEntitiesQuery, useLazyGetEntitiesQuery } from '../../../services/entities';
 import { getArtsDataEntities } from '../../../services/artsData';
+import { routinghandler } from '../../../utils/roleRoutingHandler';
 
 function SearchPlaces() {
   const { t } = useTranslation();
@@ -130,11 +131,13 @@ function SearchPlaces() {
                             )
                           }
                           linkText={t('dashboard.places.createNew.search.linkText')}
-                          onClick={() =>
-                            navigate(
-                              `${PathName.Dashboard}/${calendarId}${PathName.Places}${PathName.AddPlace}?id=${place?.id}`,
-                            )
-                          }
+                          onClick={() => {
+                            if (routinghandler(user, calendarId, place?.creator?.userId, null, true)) {
+                              navigate(
+                                `${PathName.Dashboard}/${calendarId}${PathName.Places}${PathName.AddPlace}?id=${place?.id}`,
+                              );
+                            } else navigate(`${PathName.Dashboard}/${calendarId}${PathName.Places}/${place?.id}`);
+                          }}
                         />
                       </div>
                     ))


### PR DESCRIPTION
Fix for :
Bug in the New Organization screen (with the search bar): I search for an organization and find that it already exists in Footlight. I click it and expect to see either the read only page (if I am NOT the creator of this organization) or the same page with an Edit button (if I am the creator or an Admiin). Instead I see this error page:

https://github.com/culturecreates/footlight-app/issues/457#issuecomment-1734483143