### PR TITLE
fix: added notification message and refetch for 409

### DIFF
--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -157,6 +157,7 @@ function AddEvent() {
     currentData: eventData,
     isError,
     isLoading,
+    refetch: refetchEvent,
   } = useGetEventQuery(
     { eventId: eventId ?? duplicateId, calendarId, sessionId: timestampRef },
     { skip: eventId || duplicateId ? false : true },
@@ -3066,6 +3067,16 @@ function AddEvent() {
         icon: <ExclamationCircleOutlined />,
       });
       return;
+    } else if (errorCode == 409 && data?.message) {
+      dispatch(clearErrors());
+      refetchEvent();
+      notification.warning({
+        message: t('dashboard.events.addEditEvent.validations.errorPublishing'),
+        description: data?.message,
+        placement: 'top',
+        duration: 10,
+        maxCount: 1,
+      });
     }
   }, [errorDetails, updateEventStateLoading, updateEventLoading]);
 


### PR DESCRIPTION
When saving or publishing an event, if the API rejects the request with a 409 (e.g. because linked entities have missing required fields and the event gets reverted to draft), the frontend now shows a visible warning notification with the API's message instead of staying silent. It also refetches the event details so the action buttons at the top reflect the updated publish state.