### PR TITLE
fix: added notification message and refetch for 409

### DIFF
--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -176,6 +176,7 @@ function AddEvent() {
   const [getExternalSource, { isFetching: isExternalSourceFetching }] = useLazyGetExternalSourceQuery();
   const [updateEventState, { isLoading: updateEventStateLoading }] = useUpdateEventStateMutation();
   const [updateEvent, { isLoading: updateEventLoading, isSuccess: updateEventSuccess }] = useUpdateEventMutation();
+  const hadMutationRun = useRef(false);
   const [addImage, { error: isAddImageError, isLoading: addImageLoading, reset: resetAddImage }] =
     useAddImageMutation();
   const [getAllTaxonomy] = useLazyGetAllTaxonomyQuery({ sessionId: timestampRef });
@@ -1353,27 +1354,50 @@ function AddEvent() {
       .validateFields(type === 'PUBLISH' || type === 'REVIEW' ? validateFields : [])
       .then(() => {
         if (isValuesChanged && type !== 'PUBLISH') {
-          saveAsDraftHandler(event, type !== 'PUBLISH', eventPublishState.DRAFT)
-            .then((id) => {
-              updateEventState({ id, calendarId, publishState })
-                .then(() => {
-                  notification.success({
-                    description:
-                      calendar[0]?.role === userRoles.GUEST
-                        ? t('dashboard.events.addEditEvent.notification.sendToReview')
-                        : eventData?.publishState === eventPublishState.DRAFT
-                        ? t('dashboard.events.addEditEvent.notification.publish')
-                        : t('dashboard.events.addEditEvent.notification.saveAsDraft'),
-                    placement: 'top',
-                    closeIcon: <></>,
-                    maxCount: 1,
-                    duration: 3,
-                  });
-                  navigate(`${PathName.Dashboard}/${calendarId}${PathName.Events}`);
-                })
-                .catch((error) => console.log(error));
-            })
-            .catch((error) => console.log(error));
+          if (eventData?.publishState === eventPublishState.PUBLISHED) {
+            updateEventState({ id: eventId, calendarId, publishState })
+              .unwrap()
+              .then(() => {
+                saveAsDraftHandler(event, true, eventPublishState.DRAFT)
+                  .then(() => {
+                    notification.success({
+                      description:
+                        calendar[0]?.role === userRoles.GUEST
+                          ? t('dashboard.events.addEditEvent.notification.sendToReview')
+                          : t('dashboard.events.addEditEvent.notification.saveAsDraft'),
+                      placement: 'top',
+                      closeIcon: <></>,
+                      maxCount: 1,
+                      duration: 3,
+                    });
+                    navigate(`${PathName.Dashboard}/${calendarId}${PathName.Events}`);
+                  })
+                  .catch((error) => console.log(error));
+              })
+              .catch((error) => console.log(error));
+          } else {
+            saveAsDraftHandler(event, type !== 'PUBLISH', eventPublishState.DRAFT)
+              .then((id) => {
+                updateEventState({ id, calendarId, publishState })
+                  .then(() => {
+                    notification.success({
+                      description:
+                        calendar[0]?.role === userRoles.GUEST
+                          ? t('dashboard.events.addEditEvent.notification.sendToReview')
+                          : eventData?.publishState === eventPublishState.DRAFT
+                          ? t('dashboard.events.addEditEvent.notification.publish')
+                          : t('dashboard.events.addEditEvent.notification.saveAsDraft'),
+                      placement: 'top',
+                      closeIcon: <></>,
+                      maxCount: 1,
+                      duration: 3,
+                    });
+                    navigate(`${PathName.Dashboard}/${calendarId}${PathName.Events}`);
+                  })
+                  .catch((error) => console.log(error));
+              })
+              .catch((error) => console.log(error));
+          }
         } else if (
           (isValuesChanged || Object.keys(activeFallbackFieldsInfo).length > 0 || duplicateId) &&
           (type === 'PUBLISH' || type === 'REVIEW')
@@ -3024,9 +3048,13 @@ function AddEvent() {
   }, [taxonomyLoading]);
 
   useEffect(() => {
+    if (updateEventLoading || updateEventStateLoading) hadMutationRun.current = true;
+  }, [updateEventLoading, updateEventStateLoading]);
+
+  useEffect(() => {
     const { isError, errorCode, data } = errorDetails;
 
-    if (!isError || updateEventStateLoading || updateEventLoading) return;
+    if (!isError || updateEventStateLoading || updateEventLoading || !hadMutationRun.current) return;
 
     if (errorCode == 409 && data?.inCompleteLinkedEntityIds) {
       const { updatedOrganizers, updatedPerformers, updatedSupporters, updatedLocation } =

--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -157,6 +157,7 @@ function AddEvent() {
     currentData: eventData,
     isError,
     isLoading,
+    refetch: refetchEvent,
   } = useGetEventQuery(
     { eventId: eventId ?? duplicateId, calendarId, sessionId: timestampRef },
     { skip: eventId || duplicateId ? false : true },
@@ -3066,6 +3067,16 @@ function AddEvent() {
         icon: <ExclamationCircleOutlined />,
       });
       return;
+    } else if (errorCode == 409 && data?.message) {
+      dispatch(clearErrors());
+      refetchEvent();
+      notification.warning({
+        message: t('dashboard.events.addEditEvent.validations.errorPublishing'),
+        description: data?.message,
+        placement: 'top',
+        duration: 10,
+        maxCount: 1,
+      });
     }
   }, [errorDetails, updateEventStateLoading, updateEventLoading]);
 

--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -1378,28 +1378,49 @@ function AddEvent() {
           (isValuesChanged || Object.keys(activeFallbackFieldsInfo).length > 0 || duplicateId) &&
           (type === 'PUBLISH' || type === 'REVIEW')
         ) {
-          saveAsDraftHandler(event, true, type)
-            .then((id) => {
-              updateEventState({ id: eventId ?? id, calendarId, publishState })
-                .unwrap()
-                .then(() => {
-                  notification.success({
-                    description:
-                      calendar[0]?.role === userRoles.GUEST
-                        ? t('dashboard.events.addEditEvent.notification.sendToReview')
-                        : eventData?.publishState === eventPublishState.DRAFT || type === 'PUBLISH'
-                        ? t('dashboard.events.addEditEvent.notification.publish')
-                        : t('dashboard.events.addEditEvent.notification.saveAsDraft'),
-                    placement: 'top',
-                    closeIcon: <></>,
-                    maxCount: 1,
-                    duration: 3,
-                  });
-                  navigate(`${PathName.Dashboard}/${calendarId}${PathName.Events}`);
-                })
-                .catch((error) => console.log(error));
-            })
-            .catch((error) => console.log(error));
+          if (isValuesChanged || duplicateId) {
+            saveAsDraftHandler(event, true, type)
+              .then((id) => {
+                updateEventState({ id: eventId ?? id, calendarId, publishState })
+                  .unwrap()
+                  .then(() => {
+                    notification.success({
+                      description:
+                        calendar[0]?.role === userRoles.GUEST
+                          ? t('dashboard.events.addEditEvent.notification.sendToReview')
+                          : eventData?.publishState === eventPublishState.DRAFT || type === 'PUBLISH'
+                          ? t('dashboard.events.addEditEvent.notification.publish')
+                          : t('dashboard.events.addEditEvent.notification.saveAsDraft'),
+                      placement: 'top',
+                      closeIcon: <></>,
+                      maxCount: 1,
+                      duration: 3,
+                    });
+                    navigate(`${PathName.Dashboard}/${calendarId}${PathName.Events}`);
+                  })
+                  .catch((error) => console.log(error));
+              })
+              .catch((error) => console.log(error));
+          } else if (eventId) {
+            updateEventState({ id: eventId, calendarId, publishState })
+              .unwrap()
+              .then(() => {
+                notification.success({
+                  description:
+                    calendar[0]?.role === userRoles.GUEST
+                      ? t('dashboard.events.addEditEvent.notification.sendToReview')
+                      : eventData?.publishState === eventPublishState.DRAFT || type === 'PUBLISH'
+                      ? t('dashboard.events.addEditEvent.notification.publish')
+                      : t('dashboard.events.addEditEvent.notification.saveAsDraft'),
+                  placement: 'top',
+                  closeIcon: <></>,
+                  maxCount: 1,
+                  duration: 3,
+                });
+                navigate(`${PathName.Dashboard}/${calendarId}${PathName.Events}`);
+              })
+              .catch((error) => console.log(error));
+          }
         } else {
           if (eventId) {
             updateEventState({ id: eventId, calendarId, publishState })

--- a/src/pages/Dashboard/Events/Events.jsx
+++ b/src/pages/Dashboard/Events/Events.jsx
@@ -1,6 +1,20 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
 import './events.css';
-import { Checkbox, Col, Row, Badge, Button, Dropdown, Space, Popover, Divider, Radio, Grid, Tree } from 'antd';
+import {
+  Checkbox,
+  Col,
+  Row,
+  Badge,
+  Button,
+  Dropdown,
+  Space,
+  Popover,
+  Divider,
+  Radio,
+  Grid,
+  Tree,
+  notification,
+} from 'antd';
 import { CloseCircleOutlined, DownOutlined, SortAscendingOutlined, SortDescendingOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import i18n from 'i18next';
@@ -20,7 +34,8 @@ import { eventPublishStateOptions } from '../../../constants/eventPublishState';
 import { useLazyGetAllUsersQuery } from '../../../services/users';
 import { filterTypes } from '../../../constants/filterTypes';
 import { getUserDetails } from '../../../redux/reducer/userSlice';
-import { useSelector } from 'react-redux';
+import { getErrorDetails, clearErrors } from '../../../redux/reducer/ErrorSlice';
+import { useSelector, useDispatch } from 'react-redux';
 import {
   sortByOptions,
   sortByOptionsOrgsPlacesPerson,
@@ -82,6 +97,8 @@ function Events() {
   const timestampRef = useRef(Date.now()).current;
   const screens = useBreakpoint();
   const { user } = useSelector(getUserDetails);
+  const errorDetails = useSelector(getErrorDetails);
+  const dispatch = useDispatch();
   const [
     currentCalendarData,
     pageNumber,
@@ -115,6 +132,23 @@ function Events() {
   const [deleteEvent, { isLoading: deleteEventLoading }] = useDeleteEventMutation();
   const [featureEvents, { isLoading: featureEventsLoading }] = useFeatureEventsMutation();
   const isActionLoading = updateStateLoading || deleteEventLoading || featureEventsLoading;
+  const hadMutationRun = useRef(false);
+
+  useEffect(() => {
+    if (updateStateLoading) hadMutationRun.current = true;
+  }, [updateStateLoading]);
+
+  useEffect(() => {
+    const { isError, errorCode, data } = errorDetails;
+    if (!isError || errorCode != 409 || !data?.message || !hadMutationRun.current) return;
+    dispatch(clearErrors());
+    notification.warning({
+      description: data?.message,
+      placement: 'top',
+      duration: 10,
+      maxCount: 1,
+    });
+  }, [errorDetails]);
 
   const [searchKey, setSearchKey] = useState();
   const [organizationSearchKey, setOrganizationSearchKey] = useState();


### PR DESCRIPTION
When saving or publishing an event, if the API rejects the request with a 409 (e.g. because linked entities have missing required fields and the event gets reverted to draft), the frontend now shows a visible warning notification with the API's message instead of staying silent. It also refetches the event details so the action buttons at the top reflect the updated publish state.