### PR TITLE
Fix: Image original.height/width sent as strings instead of numbers

### DIFF
--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -41,6 +41,7 @@ import Tags from '../../../components/Tags/Common/Tags';
 import { useGetAllTaxonomyQuery, useLazyGetAllTaxonomyQuery } from '../../../services/taxonomy';
 import { taxonomyClass } from '../../../constants/taxonomyClass';
 import { dateTimeTypeHandler } from '../../../utils/dateTimeTypeHandler';
+import { toFiniteNumber } from '../../../utils/toFiniteNumber';
 import ImageUpload from '../../../components/ImageUpload';
 import { useAddImageMutation } from '../../../services/image';
 import {
@@ -1170,8 +1171,8 @@ function AddEvent() {
                   },
                   original: {
                     entityId: imageCrop[0]?.original?.entityId,
-                    height: imageCrop[0]?.original?.height != null ? Number(imageCrop[0]?.original?.height) : undefined,
-                    width: imageCrop[0]?.original?.width != null ? Number(imageCrop[0]?.original?.width) : undefined,
+                    height: toFiniteNumber(imageCrop[0]?.original?.height),
+                    width: toFiniteNumber(imageCrop[0]?.original?.width),
                   },
                   isMain: true,
                   description: mainImageOptions?.altText,

--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -1170,8 +1170,8 @@ function AddEvent() {
                   },
                   original: {
                     entityId: imageCrop[0]?.original?.entityId,
-                    height: imageCrop[0]?.original?.height,
-                    width: imageCrop[0]?.original?.width,
+                    height: imageCrop[0]?.original?.height != null ? Number(imageCrop[0]?.original?.height) : undefined,
+                    width: imageCrop[0]?.original?.width != null ? Number(imageCrop[0]?.original?.width) : undefined,
                   },
                   isMain: true,
                   description: mainImageOptions?.altText,

--- a/src/pages/Dashboard/CreateNewOrganization/CreateNewOrganization.jsx
+++ b/src/pages/Dashboard/CreateNewOrganization/CreateNewOrganization.jsx
@@ -75,6 +75,7 @@ import { contentLanguageKeyMap } from '../../../constants/contentLanguage';
 import { isDataValid } from '../../../utils/MultiLingualFormItemSupportFunctions';
 import SortableTreeSelect from '../../../components/TreeSelectOption/SortableTreeSelect';
 import { uploadImageListHelper } from '../../../utils/uploadImageListHelper';
+import { toFiniteNumber } from '../../../utils/toFiniteNumber';
 import i18next from 'i18next';
 
 function CreateNewOrganization() {
@@ -396,8 +397,8 @@ function CreateNewOrganization() {
                 },
                 original: {
                   entityId: imageCrop[0]?.original?.entityId,
-                  height: imageCrop[0]?.original?.height != null ? Number(imageCrop[0]?.original?.height) : undefined,
-                  width: imageCrop[0]?.original?.width != null ? Number(imageCrop[0]?.original?.width) : undefined,
+                  height: toFiniteNumber(imageCrop[0]?.original?.height),
+                  width: toFiniteNumber(imageCrop[0]?.original?.width),
                 },
                 isMain: true,
                 description: mainImageOptions?.altText,

--- a/src/pages/Dashboard/CreateNewOrganization/CreateNewOrganization.jsx
+++ b/src/pages/Dashboard/CreateNewOrganization/CreateNewOrganization.jsx
@@ -396,8 +396,8 @@ function CreateNewOrganization() {
                 },
                 original: {
                   entityId: imageCrop[0]?.original?.entityId,
-                  height: imageCrop[0]?.original?.height,
-                  width: imageCrop[0]?.original?.width,
+                  height: imageCrop[0]?.original?.height != null ? Number(imageCrop[0]?.original?.height) : undefined,
+                  width: imageCrop[0]?.original?.width != null ? Number(imageCrop[0]?.original?.width) : undefined,
                 },
                 isMain: true,
                 description: mainImageOptions?.altText,

--- a/src/pages/Dashboard/CreateNewPerson/CreateNewPerson.jsx
+++ b/src/pages/Dashboard/CreateNewPerson/CreateNewPerson.jsx
@@ -57,6 +57,7 @@ import { contentLanguageKeyMap } from '../../../constants/contentLanguage';
 import { isDataValid } from '../../../utils/MultiLingualFormItemSupportFunctions';
 import SortableTreeSelect from '../../../components/TreeSelectOption/SortableTreeSelect';
 import { uploadImageListHelper } from '../../../utils/uploadImageListHelper';
+import { toFiniteNumber } from '../../../utils/toFiniteNumber';
 import ChangeTypeLayout from '../../../layout/ChangeTypeLayout/ChangeTypeLayout';
 import ChangeType from '../../../components/ChangeType';
 import i18next from 'i18next';
@@ -355,8 +356,8 @@ function CreateNewPerson() {
               },
               original: {
                 entityId: imageCrop[0]?.original?.entityId,
-                height: imageCrop[0]?.original?.height != null ? Number(imageCrop[0]?.original?.height) : undefined,
-                width: imageCrop[0]?.original?.width != null ? Number(imageCrop[0]?.original?.width) : undefined,
+                height: toFiniteNumber(imageCrop[0]?.original?.height),
+                width: toFiniteNumber(imageCrop[0]?.original?.width),
               },
               isMain: true,
               description: mainImageOptions?.altText,

--- a/src/pages/Dashboard/CreateNewPerson/CreateNewPerson.jsx
+++ b/src/pages/Dashboard/CreateNewPerson/CreateNewPerson.jsx
@@ -355,8 +355,8 @@ function CreateNewPerson() {
               },
               original: {
                 entityId: imageCrop[0]?.original?.entityId,
-                height: imageCrop[0]?.original?.height,
-                width: imageCrop[0]?.original?.width,
+                height: imageCrop[0]?.original?.height != null ? Number(imageCrop[0]?.original?.height) : undefined,
+                width: imageCrop[0]?.original?.width != null ? Number(imageCrop[0]?.original?.width) : undefined,
               },
               isMain: true,
               description: mainImageOptions?.altText,

--- a/src/pages/Dashboard/CreateNewPlace/CreateNewPlace.jsx
+++ b/src/pages/Dashboard/CreateNewPlace/CreateNewPlace.jsx
@@ -95,6 +95,7 @@ import MapComponent from '../../../components/MapComponent';
 import { filterUneditedFallbackValues } from '../../../utils/removeUneditedFallbackValues';
 import SortableTreeSelect from '../../../components/TreeSelectOption/SortableTreeSelect';
 import { uploadImageListHelper } from '../../../utils/uploadImageListHelper';
+import { toFiniteNumber } from '../../../utils/toFiniteNumber';
 import i18next from 'i18next';
 import { setInitialValueForStandardTaxonomyFieldsForPlaceForm } from '../../../utils/setFieldvalueForTaxonomies';
 
@@ -573,8 +574,8 @@ function CreateNewPlace() {
                 },
                 original: {
                   entityId: imageCrop[0]?.original?.entityId,
-                  height: imageCrop[0]?.original?.height != null ? Number(imageCrop[0]?.original?.height) : undefined,
-                  width: imageCrop[0]?.original?.width != null ? Number(imageCrop[0]?.original?.width) : undefined,
+                  height: toFiniteNumber(imageCrop[0]?.original?.height),
+                  width: toFiniteNumber(imageCrop[0]?.original?.width),
                 },
                 isMain: true,
                 description: mainImageOptions?.altText,

--- a/src/pages/Dashboard/CreateNewPlace/CreateNewPlace.jsx
+++ b/src/pages/Dashboard/CreateNewPlace/CreateNewPlace.jsx
@@ -573,8 +573,8 @@ function CreateNewPlace() {
                 },
                 original: {
                   entityId: imageCrop[0]?.original?.entityId,
-                  height: imageCrop[0]?.original?.height,
-                  width: imageCrop[0]?.original?.width,
+                  height: imageCrop[0]?.original?.height != null ? Number(imageCrop[0]?.original?.height) : undefined,
+                  width: imageCrop[0]?.original?.width != null ? Number(imageCrop[0]?.original?.width) : undefined,
                 },
                 isMain: true,
                 description: mainImageOptions?.altText,

--- a/src/utils/toFiniteNumber.js
+++ b/src/utils/toFiniteNumber.js
@@ -1,0 +1,9 @@
+/**
+ * Converts a value to a finite number, or returns undefined if the value
+ * is null, undefined, an empty string, or results in a non-finite number.
+ */
+export const toFiniteNumber = (value) => {
+  if (value === null || value === undefined || value === '') return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+};

--- a/src/utils/uploadImageListHelper.js
+++ b/src/utils/uploadImageListHelper.js
@@ -24,6 +24,13 @@ export const uploadImageListHelper = async (values, addImage, calendarId, imageC
 
       imageCrop.push({
         ...cropData,
+        ...(cropData?.original && {
+          original: {
+            ...cropData.original,
+            height: cropData.original?.height != null ? Number(cropData.original.height) : undefined,
+            width: cropData.original?.width != null ? Number(cropData.original.width) : undefined,
+          },
+        }),
         ...filteredImageOptions,
       });
       continue;

--- a/src/utils/uploadImageListHelper.js
+++ b/src/utils/uploadImageListHelper.js
@@ -1,4 +1,5 @@
 import { filterNonEmptyValues } from './filterNonEmptyValues';
+import { toFiniteNumber } from './toFiniteNumber';
 
 export const uploadImageListHelper = async (values, addImage, calendarId, imageCrop) => {
   for (const imageItem of values.multipleImagesCrop) {
@@ -27,8 +28,8 @@ export const uploadImageListHelper = async (values, addImage, calendarId, imageC
         ...(cropData?.original && {
           original: {
             ...cropData.original,
-            height: cropData.original?.height != null ? Number(cropData.original.height) : undefined,
-            width: cropData.original?.width != null ? Number(cropData.original.width) : undefined,
+            height: toFiniteNumber(cropData.original?.height),
+            width: toFiniteNumber(cropData.original?.width),
           },
         }),
         ...filteredImageOptions,


### PR DESCRIPTION
When an entity (event, place, organization, person) is loaded from the API, the image[].original.height and image[].original.width are returned as strings (e.g., "560", "800"). These values are stored in the Ant Design form as-is. When the entity is saved, onSaveHandler reads these form values and builds the image payload — still as strings — which the backend API rejects with:


"image.0.original.width must be a number conforming to the specified constraints"
"image.0.original.height must be a number conforming to the specified constraints"

The fix is to convert original.height and original.width to Number() at the payload-building stage in each onSaveHandler, and in the uploadImageListHelper for gallery images.

[src/utils/toFiniteNumber.js]) — shared utility handling null, undefined, "", non-numeric strings, and NaN