### PR TITLE
Restrict Contributors from Editing Non-Draft Events

### DIFF
--- a/src/components/Dropdown/EventStatus/EventStatus.jsx
+++ b/src/components/Dropdown/EventStatus/EventStatus.jsx
@@ -8,10 +8,6 @@ import ProtectedComponents from '../../../layout/ProtectedComponents';
 import { eventPublishState } from '../../../constants/eventPublishState';
 import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
 import { PathName } from '../../../constants/pathName';
-import { useSelector } from 'react-redux';
-import { getUserDetails } from '../../../redux/reducer/userSlice';
-import { userRoles } from '../../../constants/userRoles';
-import { getCurrentCalendarDetailsFromUserDetails } from '../../../utils/getCurrentCalendarDetailsFromUserDetails';
 const { confirm } = Modal;
 function EventStatusOptions({
   children,
@@ -29,58 +25,52 @@ function EventStatusOptions({
   const { calendarId } = useParams();
   const navigate = useNavigate();
   const [, , , , , isReadOnly] = useOutletContext();
-  const { user } = useSelector(getUserDetails);
-  const calendar = getCurrentCalendarDetailsFromUserDetails(user, calendarId);
-  const isContributor = calendar[0]?.role === userRoles.CONTRIBUTOR;
-
-  const items = eventPublishOptions
-    .filter((item) => !isContributor || (item.key !== '4' && item.key !== '5'))
-    .map((item) => {
-      if (publishState == eventPublishState.PUBLISHED) {
-        if (item.key != '0' && item.key != '6') {
-          if (isFeatured) {
-            if (item.key !== '4') {
-              return {
-                key: item?.key,
-                label: item?.label,
-                type: item?.type,
-              };
-            }
-          } else {
-            if (item.key !== '5') {
-              return {
-                key: item?.key,
-                label: item?.label,
-                type: item?.type,
-              };
-            }
+  const items = eventPublishOptions.map((item) => {
+    if (publishState == eventPublishState.PUBLISHED) {
+      if (item.key != '0' && item.key != '6') {
+        if (isFeatured) {
+          if (item.key !== '4') {
+            return {
+              key: item?.key,
+              label: item?.label,
+              type: item?.type,
+            };
+          }
+        } else {
+          if (item.key !== '5') {
+            return {
+              key: item?.key,
+              label: item?.label,
+              type: item?.type,
+            };
           }
         }
-      } else {
-        if (publishState == eventPublishState.DRAFT || publishState === eventPublishState.PENDING_REVIEW)
-          if (item.key != '1' && item.key !== '5' && item.key !== '4') {
-            if (item.key === '6') {
-              if (publishState === eventPublishState.PENDING_REVIEW)
-                return {
-                  key: item?.key,
-                  label: item?.label,
-                  type: item?.type,
-                };
-            } else
+      }
+    } else {
+      if (publishState == eventPublishState.DRAFT || publishState === eventPublishState.PENDING_REVIEW)
+        if (item.key != '1' && item.key !== '5' && item.key !== '4') {
+          if (item.key === '6') {
+            if (publishState === eventPublishState.PENDING_REVIEW)
               return {
                 key: item?.key,
                 label: item?.label,
                 type: item?.type,
               };
-          }
-        if (item?.type === 'divider')
-          return {
-            key: item?.key,
-            label: item?.label,
-            type: item?.type,
-          };
-      }
-    });
+          } else
+            return {
+              key: item?.key,
+              label: item?.label,
+              type: item?.type,
+            };
+        }
+      if (item?.type === 'divider')
+        return {
+          key: item?.key,
+          label: item?.label,
+          type: item?.type,
+        };
+    }
+  });
 
   const showDeleteConfirm = () => {
     confirm({

--- a/src/components/Dropdown/EventStatus/EventStatus.jsx
+++ b/src/components/Dropdown/EventStatus/EventStatus.jsx
@@ -8,6 +8,10 @@ import ProtectedComponents from '../../../layout/ProtectedComponents';
 import { eventPublishState } from '../../../constants/eventPublishState';
 import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
 import { PathName } from '../../../constants/pathName';
+import { useSelector } from 'react-redux';
+import { getUserDetails } from '../../../redux/reducer/userSlice';
+import { userRoles } from '../../../constants/userRoles';
+import { getCurrentCalendarDetailsFromUserDetails } from '../../../utils/getCurrentCalendarDetailsFromUserDetails';
 const { confirm } = Modal;
 function EventStatusOptions({
   children,
@@ -25,53 +29,58 @@ function EventStatusOptions({
   const { calendarId } = useParams();
   const navigate = useNavigate();
   const [, , , , , isReadOnly] = useOutletContext();
+  const { user } = useSelector(getUserDetails);
+  const calendar = getCurrentCalendarDetailsFromUserDetails(user, calendarId);
+  const isContributor = calendar[0]?.role === userRoles.CONTRIBUTOR;
 
-  const items = eventPublishOptions.map((item) => {
-    if (publishState == eventPublishState.PUBLISHED) {
-      if (item.key != '0' && item.key != '6') {
-        if (isFeatured) {
-          if (item.key !== '4') {
-            return {
-              key: item?.key,
-              label: item?.label,
-              type: item?.type,
-            };
-          }
-        } else {
-          if (item.key !== '5') {
-            return {
-              key: item?.key,
-              label: item?.label,
-              type: item?.type,
-            };
-          }
-        }
-      }
-    } else {
-      if (publishState == eventPublishState.DRAFT || publishState === eventPublishState.PENDING_REVIEW)
-        if (item.key != '1' && item.key !== '5' && item.key !== '4') {
-          if (item.key === '6') {
-            if (publishState === eventPublishState.PENDING_REVIEW)
+  const items = eventPublishOptions
+    .filter((item) => !isContributor || (item.key !== '4' && item.key !== '5'))
+    .map((item) => {
+      if (publishState == eventPublishState.PUBLISHED) {
+        if (item.key != '0' && item.key != '6') {
+          if (isFeatured) {
+            if (item.key !== '4') {
               return {
                 key: item?.key,
                 label: item?.label,
                 type: item?.type,
               };
-          } else
-            return {
-              key: item?.key,
-              label: item?.label,
-              type: item?.type,
-            };
+            }
+          } else {
+            if (item.key !== '5') {
+              return {
+                key: item?.key,
+                label: item?.label,
+                type: item?.type,
+              };
+            }
+          }
         }
-      if (item?.type === 'divider')
-        return {
-          key: item?.key,
-          label: item?.label,
-          type: item?.type,
-        };
-    }
-  });
+      } else {
+        if (publishState == eventPublishState.DRAFT || publishState === eventPublishState.PENDING_REVIEW)
+          if (item.key != '1' && item.key !== '5' && item.key !== '4') {
+            if (item.key === '6') {
+              if (publishState === eventPublishState.PENDING_REVIEW)
+                return {
+                  key: item?.key,
+                  label: item?.label,
+                  type: item?.type,
+                };
+            } else
+              return {
+                key: item?.key,
+                label: item?.label,
+                type: item?.type,
+              };
+          }
+        if (item?.type === 'divider')
+          return {
+            key: item?.key,
+            label: item?.label,
+            type: item?.type,
+          };
+      }
+    });
 
   const showDeleteConfirm = () => {
     confirm({

--- a/src/components/Dropdown/EventStatus/EventStatus.jsx
+++ b/src/components/Dropdown/EventStatus/EventStatus.jsx
@@ -8,6 +8,10 @@ import ProtectedComponents from '../../../layout/ProtectedComponents';
 import { eventPublishState } from '../../../constants/eventPublishState';
 import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
 import { PathName } from '../../../constants/pathName';
+import { useSelector } from 'react-redux';
+import { getUserDetails } from '../../../redux/reducer/userSlice';
+import { userRoles } from '../../../constants/userRoles';
+import { getCurrentCalendarDetailsFromUserDetails } from '../../../utils/getCurrentCalendarDetailsFromUserDetails';
 const { confirm } = Modal;
 function EventStatusOptions({
   children,
@@ -25,52 +29,58 @@ function EventStatusOptions({
   const { calendarId } = useParams();
   const navigate = useNavigate();
   const [, , , , , isReadOnly] = useOutletContext();
-  const items = eventPublishOptions.map((item) => {
-    if (publishState == eventPublishState.PUBLISHED) {
-      if (item.key != '0' && item.key != '6') {
-        if (isFeatured) {
-          if (item.key !== '4') {
-            return {
-              key: item?.key,
-              label: item?.label,
-              type: item?.type,
-            };
-          }
-        } else {
-          if (item.key !== '5') {
-            return {
-              key: item?.key,
-              label: item?.label,
-              type: item?.type,
-            };
-          }
-        }
-      }
-    } else {
-      if (publishState == eventPublishState.DRAFT || publishState === eventPublishState.PENDING_REVIEW)
-        if (item.key != '1' && item.key !== '5' && item.key !== '4') {
-          if (item.key === '6') {
-            if (publishState === eventPublishState.PENDING_REVIEW)
+  const { user } = useSelector(getUserDetails);
+  const calendar = getCurrentCalendarDetailsFromUserDetails(user, calendarId);
+  const canFeature = [userRoles.ADMIN, userRoles.EDITOR].includes(calendar[0]?.role) || user?.isSuperAdmin;
+
+  const items = eventPublishOptions
+    .filter((item) => canFeature || (item.key !== '4' && item.key !== '5'))
+    .map((item) => {
+      if (publishState == eventPublishState.PUBLISHED) {
+        if (item.key != '0' && item.key != '6') {
+          if (isFeatured) {
+            if (item.key !== '4') {
               return {
                 key: item?.key,
                 label: item?.label,
                 type: item?.type,
               };
-          } else
-            return {
-              key: item?.key,
-              label: item?.label,
-              type: item?.type,
-            };
+            }
+          } else {
+            if (item.key !== '5') {
+              return {
+                key: item?.key,
+                label: item?.label,
+                type: item?.type,
+              };
+            }
+          }
         }
-      if (item?.type === 'divider')
-        return {
-          key: item?.key,
-          label: item?.label,
-          type: item?.type,
-        };
-    }
-  });
+      } else {
+        if (publishState == eventPublishState.DRAFT || publishState === eventPublishState.PENDING_REVIEW)
+          if (item.key != '1' && item.key !== '5' && item.key !== '4') {
+            if (item.key === '6') {
+              if (publishState === eventPublishState.PENDING_REVIEW)
+                return {
+                  key: item?.key,
+                  label: item?.label,
+                  type: item?.type,
+                };
+            } else
+              return {
+                key: item?.key,
+                label: item?.label,
+                type: item?.type,
+              };
+          }
+        if (item?.type === 'divider')
+          return {
+            key: item?.key,
+            label: item?.label,
+            type: item?.type,
+          };
+      }
+    });
 
   const showDeleteConfirm = () => {
     confirm({

--- a/src/layout/ReadOnlyProtectedComponent/ReadOnlyProtectedComponent.jsx
+++ b/src/layout/ReadOnlyProtectedComponent/ReadOnlyProtectedComponent.jsx
@@ -44,8 +44,12 @@ function ReadOnlyProtectedComponent({ children, creator, entityId, isReadOnly, e
         return children;
       }
 
-      case userRoles.CONTRIBUTOR:
-        return user?.id === creator || entityAccess ? children : undefined;
+      case userRoles.CONTRIBUTOR: {
+        const canAccess = user?.id === creator || entityAccess;
+        if (!canAccess) return;
+        if (eventState && eventState !== eventPublishState.DRAFT) return;
+        return children;
+      }
 
       case userRoles.EDITOR:
       case userRoles.ADMIN:

--- a/src/locales/en/translationEn.json
+++ b/src/locales/en/translationEn.json
@@ -128,7 +128,7 @@
         "notification": {
           "underReview": "This event is under review.",
           "underPublished": "This event has been published. If you would like to make a change, please contact the calendar admin at {{adminEmail}}.",
-          "contributorPublished": "This event is published. To make a change, use the context menu located to the right of the event in the List view and unpublish the event."
+          "contributorPublished": "Want to edit this event? Return to the event list and unpublish it first via the event's context menu."
         }
       },
       "addEditEvent": {

--- a/src/locales/en/translationEn.json
+++ b/src/locales/en/translationEn.json
@@ -127,7 +127,8 @@
       "readOnlyEvent": {
         "notification": {
           "underReview": "This event is under review.",
-          "underPublished": "This event has been published. If you would like to make a change, please contact the calendar admin at {{adminEmail}}."
+          "underPublished": "This event has been published. If you would like to make a change, please contact the calendar admin at {{adminEmail}}.",
+          "contributorPublished": "This event is published. To make a change, use the context menu located to the right of the event in the List view and unpublish the event."
         }
       },
       "addEditEvent": {

--- a/src/locales/fr/transalationFr.json
+++ b/src/locales/fr/transalationFr.json
@@ -128,7 +128,7 @@
         "notification": {
           "underReview": "Cet événement est en cours de validation.",
           "underPublished": "Cet événement a été publié. Si vous voulez faire des changements, veuillez contacter l'administrateur du calendrier à {{adminEmail}}.",
-          "contributorPublished": "Cet événement est publié. Pour apporter une modification, utilisez le menu contextuel situé à droite de l'événement à la vue Liste et désactivez la publication de l'événement."
+          "contributorPublished": "Voulez-vous modifier cet événement ? Retournez à la liste des événements et désactivez sa publication en premier via le menu contextuel de l'événement."
         }
       },
       "addEditEvent": {

--- a/src/locales/fr/transalationFr.json
+++ b/src/locales/fr/transalationFr.json
@@ -127,7 +127,8 @@
       "readOnlyEvent": {
         "notification": {
           "underReview": "Cet événement est en cours de validation.",
-          "underPublished": "Cet événement a été publié. Si vous voulez faire des changements, veuillez contacter l'administrateur du calendrier à {{adminEmail}}."
+          "underPublished": "Cet événement a été publié. Si vous voulez faire des changements, veuillez contacter l'administrateur du calendrier à {{adminEmail}}.",
+          "contributorPublished": "Cet événement est publié. Pour apporter une modification, utilisez le menu contextuel situé à droite de l'événement à la vue Liste et désactivez la publication de l'événement."
         }
       },
       "addEditEvent": {

--- a/src/pages/Dashboard/EventReadOnly/EventReadOnly.jsx
+++ b/src/pages/Dashboard/EventReadOnly/EventReadOnly.jsx
@@ -47,6 +47,7 @@ import { adminCheckHandler } from '../../../utils/adminCheckHandler';
 import { getCurrentCalendarDetailsFromUserDetails } from '../../../utils/getCurrentCalendarDetailsFromUserDetails';
 import ReadOnlyProtectedComponent from '../../../layout/ReadOnlyProtectedComponent';
 import { PathName } from '../../../constants/pathName';
+import { userRoles } from '../../../constants/userRoles';
 import { routinghandler } from '../../../utils/roleRoutingHandler';
 import ReadOnlyPageTabLayout from '../../../layout/ReadOnlyPageTabLayout';
 import { getActiveTabKey } from '../../../redux/reducer/readOnlyTabSlice';
@@ -397,8 +398,11 @@ function EventReadOnly() {
                       state?.value === eventPublishState?.PUBLISHED) &&
                     eventData?.publishState === state?.value
                   ) {
+                    const isContributor = calendar[0]?.role === userRoles.CONTRIBUTOR;
                     const translationKey =
-                      state?.value === eventPublishState?.PUBLISHED
+                      state?.value === eventPublishState?.PUBLISHED && isContributor
+                        ? 'dashboard.events.readOnlyEvent.notification.contributorPublished'
+                        : state?.value === eventPublishState?.PUBLISHED
                         ? 'dashboard.events.readOnlyEvent.notification.underPublished'
                         : 'dashboard.events.readOnlyEvent.notification.underReview';
 

--- a/src/utils/roleRoutingHandler.js
+++ b/src/utils/roleRoutingHandler.js
@@ -31,8 +31,13 @@ export const routinghandler = (user, calendarId, creatorId, publishState = '', i
       } else return false;
       break;
     case userRoles.CONTRIBUTOR:
-      if (user?.id === creatorId || entityAccess) return true;
-      else return false;
+      if (user?.id === creatorId || entityAccess) {
+        if (isEntity == false) {
+          if (eventPublishState.DRAFT === publishState) return true;
+          else return false;
+        } else if (isEntity == true) return true;
+      } else return false;
+      break;
     case userRoles.EDITOR:
       return true;
     case userRoles.ADMIN:


### PR DESCRIPTION
Summary

- Restrict edit form access: Contributors can no longer open the edit form for their own events that are in Published state — they are redirected to the read-only view. Draft events remain fully editable.
- Hide Edit button in read-only view: The Edit button on the event read-only page is now hidden for contributors when the event is not in Draft state.

- Unpublish preserved: Contributors retain the ability to unpublish their own events to Draft via the list dropdown.

-Hide feature and unfeature button for contributors.

Files Changed

- src/utils/roleRoutingHandler.js — Added publishState check for CONTRIBUTOR role (mirrors existing GUEST logic); entity editing remains unrestricted.
- src/layout/ReadOnlyProtectedComponent/ReadOnlyProtectedComponent.jsx — Hide Edit button for contributors on non-draft events.
- src/components/Dropdown/EventStatus/EventStatus.jsx — Filter out Feature/Unfeature options from the dropdown for contributor users.