### PR TITLE
Reset page number to 1 on filter change

### DIFF
--- a/src/pages/Dashboard/Events/Events.jsx
+++ b/src/pages/Dashboard/Events/Events.jsx
@@ -392,6 +392,7 @@ function Events() {
       const { [taxonomy]: removedKey, ...updatedFilter } = taxonomyFilter;
       setTaxonomyFilter(updatedFilter);
     } else setTaxonomyFilter({ ...taxonomyFilter, [taxonomy]: checkedKeys });
+    setPageNumber(1);
   };
 
   const onStandardTaxonomyCheck = ({ checkedKeys, taxonomy }) => {
@@ -400,6 +401,7 @@ function Events() {
       const { [taxonomy]: removedKey, ...updatedFilter } = standardTaxonomyFilter;
       setStandardTaxonomyFilter(updatedFilter);
     } else setStandardTaxonomyFilter({ ...standardTaxonomyFilter, [taxonomy]: checkedKeys });
+    setPageNumber(1);
   };
 
   const onFilterChange = (values, filterType) => {

--- a/src/pages/Dashboard/Organizations/Organizations.jsx
+++ b/src/pages/Dashboard/Organizations/Organizations.jsx
@@ -203,6 +203,7 @@ function Organizations() {
       const { [taxonomy]: removedKey, ...updatedFilter } = taxonomyFilter;
       setTaxonomyFilter(updatedFilter);
     } else setTaxonomyFilter({ ...taxonomyFilter, [taxonomy]: checkedKeys });
+    setPageNumber(1);
   };
 
   const onStandardTaxonomyCheck = ({ checkedKeys, taxonomy }) => {
@@ -211,6 +212,7 @@ function Organizations() {
       const { [taxonomy]: removedKey, ...updatedFilter } = standardTaxonomyFilter;
       setStandardTaxonomyFilter(updatedFilter);
     } else setStandardTaxonomyFilter({ ...standardTaxonomyFilter, [taxonomy]: checkedKeys });
+    setPageNumber(1);
   };
 
   const filterClearHandler = () => {

--- a/src/pages/Dashboard/People/People.jsx
+++ b/src/pages/Dashboard/People/People.jsx
@@ -202,6 +202,7 @@ function People() {
       const { [taxonomy]: removedKey, ...updatedFilter } = taxonomyFilter;
       setTaxonomyFilter(updatedFilter);
     } else setTaxonomyFilter({ ...taxonomyFilter, [taxonomy]: checkedKeys });
+    setPageNumber(1);
   };
 
   const onStandardTaxonomyCheck = ({ checkedKeys, taxonomy }) => {
@@ -210,6 +211,7 @@ function People() {
       const { [taxonomy]: removedKey, ...updatedFilter } = standardTaxonomyFilter;
       setStandardTaxonomyFilter(updatedFilter);
     } else setStandardTaxonomyFilter({ ...standardTaxonomyFilter, [taxonomy]: checkedKeys });
+    setPageNumber(1);
   };
 
   const filterClearHandler = () => {

--- a/src/pages/Dashboard/Places/Places.jsx
+++ b/src/pages/Dashboard/Places/Places.jsx
@@ -218,6 +218,7 @@ function Places() {
       const { [taxonomy]: removedKey, ...updatedFilter } = taxonomyFilter;
       setTaxonomyFilter(updatedFilter);
     } else setTaxonomyFilter({ ...taxonomyFilter, [taxonomy]: checkedKeys });
+    setPageNumber(1);
   };
 
   const onStandardTaxonomyCheck = ({ checkedKeys, taxonomy }) => {
@@ -226,6 +227,7 @@ function Places() {
       const { [taxonomy]: removedKey, ...updatedFilter } = standardTaxonomyFilter;
       setStandardTaxonomyFilter(updatedFilter);
     } else setStandardTaxonomyFilter({ ...standardTaxonomyFilter, [taxonomy]: checkedKeys });
+    setPageNumber(1);
   };
 
   const filterClearHandler = () => {


### PR DESCRIPTION
https://github.com/culturecreates/tech-support-tickets/issues/130#issuecomment-4129115894
This pull request ensures that whenever taxonomy filters are changed in the dashboard pages (`Events`, `Organizations`, `People`, and `Places`), the pagination resets to the first page. This provides a better user experience by showing the most relevant results after a filter change.

Pagination reset on filter change:

* Added `setPageNumber(1);` after updating taxonomy filters in the `Events`, `Organizations`, `People`, and `Places` dashboard pages to ensure the view always resets to the first page when filters are changed. [[1]](diffhunk://#diff-53e1775d15b31ee41a29af44278114f697491f4f47c6cfdca84805257329bd55R395) [[2]](diffhunk://#diff-53e1775d15b31ee41a29af44278114f697491f4f47c6cfdca84805257329bd55R404) [[3]](diffhunk://#diff-eb021b9450dc17f8965a2713103daff02ae66b0f805061a68b124fdf0727f16fR206) [[4]](diffhunk://#diff-eb021b9450dc17f8965a2713103daff02ae66b0f805061a68b124fdf0727f16fR215) [[5]](diffhunk://#diff-036bec836d907bbf62f5e0ce53ea5b9570b545192b56585b4b553a45a0c21be4R205) [[6]](diffhunk://#diff-036bec836d907bbf62f5e0ce53ea5b9570b545192b56585b4b553a45a0c21be4R214) [[7]](diffhunk://#diff-0320145f9c75fa4863b19f95cf75b9cfae71e153b709613678bf9aac490a3852R221) [[8]](diffhunk://#diff-0320145f9c75fa4863b19f95cf75b9cfae71e153b709613678bf9aac490a3852R230)