### PR TITLE
Add abort functionality to listing queries

### DIFF
--- a/src/pages/Dashboard/Events/Events.jsx
+++ b/src/pages/Dashboard/Events/Events.jsx
@@ -138,6 +138,7 @@ function Events() {
   const [featureEvents, { isLoading: featureEventsLoading }] = useFeatureEventsMutation();
   const isActionLoading = updateStateLoading || deleteEventLoading || featureEventsLoading;
   const hadMutationRun = useRef(false);
+  const lastEventsRequestRef = useRef({ promise: null, key: null });
 
   useEffect(() => {
     if (updateStateLoading) hadMutationRun.current = true;
@@ -417,7 +418,6 @@ function Events() {
     setFilter({
       ...filter,
       sort: selectedKeys[0],
-      order: sortOrder?.ASC,
     });
     setPageNumber(1);
   };
@@ -586,15 +586,28 @@ function Events() {
       query.append('start-date-range', '');
       query.append('end-date-range', '');
     }
-    getEvents({
+    const requestKey = [
       pageNumber,
-      limit: 10,
       calendarId,
-      query: eventSearchQuery,
-      filterkeys: decodeURIComponent(query.toString()),
-      sort: sortQuery,
-      sessionId: timestampRef,
-    });
+      eventSearchQuery,
+      decodeURIComponent(query.toString()),
+      sortQuery.toString(),
+    ].join('|');
+    if (lastEventsRequestRef.current.promise && lastEventsRequestRef.current.key !== requestKey) {
+      lastEventsRequestRef.current.promise.abort();
+    }
+    lastEventsRequestRef.current = {
+      promise: getEvents({
+        pageNumber,
+        limit: 10,
+        calendarId,
+        query: eventSearchQuery,
+        filterkeys: decodeURIComponent(query.toString()),
+        sort: sortQuery.toString(),
+        sessionId: timestampRef,
+      }),
+      key: requestKey,
+    };
 
     let params = {
       page: pageNumber,

--- a/src/pages/Dashboard/Organizations/Organizations.jsx
+++ b/src/pages/Dashboard/Organizations/Organizations.jsx
@@ -56,6 +56,7 @@ function Organizations() {
   const location = useLocation();
   const screens = useBreakpoint();
   const timestampRef = useRef(Date.now()).current;
+  const lastOrgsRequestRef = useRef({ promise: null, key: null });
   const { calendarId } = useParams();
   let [searchParams, setSearchParams] = useSearchParams();
   const { user } = useSelector(getUserDetails);
@@ -319,14 +320,23 @@ function Organizations() {
       }
     });
 
-    getAllOrganization({
-      calendarId,
-      sessionId: timestampRef,
-      pageNumber,
-      query: organizationSearchQuery,
-      sort: sortQuery,
-      filterKeys: query,
-    });
+    const requestKey = [pageNumber, calendarId, organizationSearchQuery, query.toString(), sortQuery.toString()].join(
+      '|',
+    );
+    if (lastOrgsRequestRef.current.promise && lastOrgsRequestRef.current.key !== requestKey) {
+      lastOrgsRequestRef.current.promise.abort();
+    }
+    lastOrgsRequestRef.current = {
+      promise: getAllOrganization({
+        calendarId,
+        sessionId: timestampRef,
+        pageNumber,
+        query: organizationSearchQuery,
+        sort: sortQuery.toString(),
+        filterKeys: query.toString(),
+      }),
+      key: requestKey,
+    };
     let params = {
       page: pageNumber,
       order: filter?.order,

--- a/src/pages/Dashboard/People/People.jsx
+++ b/src/pages/Dashboard/People/People.jsx
@@ -61,6 +61,7 @@ function People() {
   const location = useLocation();
   const navigate = useNavigate();
   const timestampRef = useRef(Date.now()).current;
+  const lastPeopleRequestRef = useRef({ promise: null, key: null });
   const { calendarId } = useParams();
   let [searchParams, setSearchParams] = useSearchParams();
   const { user } = useSelector(getUserDetails);
@@ -328,14 +329,21 @@ function People() {
         });
       }
     });
-    getAllPeople({
-      calendarId,
-      sessionId: timestampRef,
-      pageNumber,
-      query: peopleSearchQuery,
-      sort: sortQuery,
-      filterKeys: query,
-    });
+    const requestKey = [pageNumber, calendarId, peopleSearchQuery, query.toString(), sortQuery.toString()].join('|');
+    if (lastPeopleRequestRef.current.promise && lastPeopleRequestRef.current.key !== requestKey) {
+      lastPeopleRequestRef.current.promise.abort();
+    }
+    lastPeopleRequestRef.current = {
+      promise: getAllPeople({
+        calendarId,
+        sessionId: timestampRef,
+        pageNumber,
+        query: peopleSearchQuery,
+        sort: sortQuery.toString(),
+        filterKeys: query.toString(),
+      }),
+      key: requestKey,
+    };
     let params = {
       page: pageNumber,
       order: filter?.order,

--- a/src/pages/Dashboard/Places/Places.jsx
+++ b/src/pages/Dashboard/Places/Places.jsx
@@ -69,6 +69,7 @@ function Places() {
   const location = useLocation();
   const navigate = useNavigate();
   const timestampRef = useRef(Date.now()).current;
+  const lastPlacesRequestRef = useRef({ promise: null, key: null });
   const { calendarId } = useParams();
   let [searchParams, setSearchParams] = useSearchParams();
   const { user } = useSelector(getUserDetails);
@@ -341,14 +342,21 @@ function Places() {
         });
       }
     });
-    getAllPlaces({
-      calendarId,
-      sessionId: timestampRef,
-      pageNumber,
-      query: placesSearchQuery,
-      sort: sortQuery,
-      filterKeys: query,
-    });
+    const requestKey = [pageNumber, calendarId, placesSearchQuery, query.toString(), sortQuery.toString()].join('|');
+    if (lastPlacesRequestRef.current.promise && lastPlacesRequestRef.current.key !== requestKey) {
+      lastPlacesRequestRef.current.promise.abort();
+    }
+    lastPlacesRequestRef.current = {
+      promise: getAllPlaces({
+        calendarId,
+        sessionId: timestampRef,
+        pageNumber,
+        query: placesSearchQuery,
+        sort: sortQuery.toString(),
+        filterKeys: query.toString(),
+      }),
+      key: requestKey,
+    };
     let params = {
       page: pageNumber,
       order: filter?.order,

--- a/src/pages/Dashboard/Settings/UserManagement/UserManagement.jsx
+++ b/src/pages/Dashboard/Settings/UserManagement/UserManagement.jsx
@@ -54,6 +54,7 @@ const UserManagement = (props) => {
   const { tabKey } = props;
   const { calendarId } = useParams();
   const timestampRef = useRef(Date.now()).current;
+  const lastUsersRequestRef = useRef({ promise: null, key: null });
   const { t } = useTranslation();
   const { user } = useSelector(getUserDetails);
   let [searchParams, setSearchParams] = useSearchParams();
@@ -103,15 +104,22 @@ const UserManagement = (props) => {
 
     const filtersDecoded = setFiletrsForApiCall();
 
-    getAllUsers({
-      page: pageNumber,
-      limit: 10,
-      filters: filtersDecoded,
-      query: userSearchQuery,
-      sessionId: timestampRef,
-      calendarId: calendarId,
-      includeCalenderFilter: true,
-    });
+    const requestKey = [pageNumber, calendarId, userSearchQuery, filtersDecoded].join('|');
+    if (lastUsersRequestRef.current.promise && lastUsersRequestRef.current.key !== requestKey) {
+      lastUsersRequestRef.current.promise.abort();
+    }
+    lastUsersRequestRef.current = {
+      promise: getAllUsers({
+        page: pageNumber,
+        limit: 10,
+        filters: filtersDecoded,
+        query: userSearchQuery,
+        sessionId: timestampRef,
+        calendarId: calendarId,
+        includeCalenderFilter: true,
+      }),
+      key: requestKey,
+    };
 
     let params = {
       page: pageNumber,

--- a/src/pages/Dashboard/Taxonomy/Taxonomy.jsx
+++ b/src/pages/Dashboard/Taxonomy/Taxonomy.jsx
@@ -41,6 +41,7 @@ const { useBreakpoint } = Grid;
 const Taxonomy = () => {
   const { calendarId } = useParams();
   const timestampRef = useRef(Date.now()).current;
+  const lastTaxonomyRequestRef = useRef({ promise: null, key: null });
   let [searchParams, setSearchParams] = useSearchParams();
   const { user } = useSelector(getUserDetails);
   const { t } = useTranslation();
@@ -102,15 +103,22 @@ const Taxonomy = () => {
   useEffect(() => {
     const filtersDecoded = setFiletrsForApiCall();
 
-    getAllTaxonomy({
-      calendarId,
-      query: filters.query,
-      filters: filtersDecoded,
-      taxonomyClass: '',
-      includeConcepts: false,
-      page: pageNumber,
-      limit: 10,
-    });
+    const requestKey = [pageNumber, calendarId, filters.query, filtersDecoded].join('|');
+    if (lastTaxonomyRequestRef.current.promise && lastTaxonomyRequestRef.current.key !== requestKey) {
+      lastTaxonomyRequestRef.current.promise.abort();
+    }
+    lastTaxonomyRequestRef.current = {
+      promise: getAllTaxonomy({
+        calendarId,
+        query: filters.query,
+        filters: filtersDecoded,
+        taxonomyClass: '',
+        includeConcepts: false,
+        page: pageNumber,
+        limit: 10,
+      }),
+      key: requestKey,
+    };
 
     let params = {
       page: pageNumber,


### PR DESCRIPTION
This pull request introduces a consistent request deduplication and abort mechanism across multiple dashboard pages to prevent race conditions and unnecessary API calls when rapidly changing filters, search queries, or pagination. The main change is the introduction of a `last<Request>RequestRef` ref in each relevant component, which tracks the latest request and aborts any previous one if a new request with different parameters is made.

**Request deduplication and abort logic added to dashboard pages:**

* **Events Page**
  - Added `lastEventsRequestRef` to track and abort previous event fetch requests if a new one is triggered with different parameters, ensuring only the most recent request is active. [[1]](diffhunk://#diff-53e1775d15b31ee41a29af44278114f697491f4f47c6cfdca84805257329bd55R141) [[2]](diffhunk://#diff-53e1775d15b31ee41a29af44278114f697491f4f47c6cfdca84805257329bd55L589-R610)
  - Fixed sort order handling in the filter state update to avoid passing an undefined value.

* **Organizations, People, and Places Pages**
  - Added `lastOrgsRequestRef`, `lastPeopleRequestRef`, and `lastPlacesRequestRef` respectively, implementing the same deduplication and abort logic for organization, people, and place fetch requests. [[1]](diffhunk://#diff-eb021b9450dc17f8965a2713103daff02ae66b0f805061a68b124fdf0727f16fR59) [[2]](diffhunk://#diff-eb021b9450dc17f8965a2713103daff02ae66b0f805061a68b124fdf0727f16fL322-R339) [[3]](diffhunk://#diff-036bec836d907bbf62f5e0ce53ea5b9570b545192b56585b4b553a45a0c21be4R64) [[4]](diffhunk://#diff-036bec836d907bbf62f5e0ce53ea5b9570b545192b56585b4b553a45a0c21be4L331-R346) [[5]](diffhunk://#diff-0320145f9c75fa4863b19f95cf75b9cfae71e153b709613678bf9aac490a3852R72) [[6]](diffhunk://#diff-0320145f9c75fa4863b19f95cf75b9cfae71e153b709613678bf9aac490a3852L344-R359)

* **User Management and Taxonomy Pages**
  - Introduced `lastUsersRequestRef` and `lastTaxonomyRequestRef` to manage and abort overlapping user and taxonomy fetch requests, reducing unnecessary network activity and potential data inconsistencies. [[1]](diffhunk://#diff-c20e152b21c1be40ea7b9d0520579597d4ab6fa721e301473431f7ccd085599dR57) [[2]](diffhunk://#diff-c20e152b21c1be40ea7b9d0520579597d4ab6fa721e301473431f7ccd085599dL106-R122) [[3]](diffhunk://#diff-cf9f0852ed302a42b7a8361e6cd2faecec657653d0140036a1272b4186fd7f0dR44) [[4]](diffhunk://#diff-cf9f0852ed302a42b7a8361e6cd2faecec657653d0140036a1272b4186fd7f0dL105-R121)

These changes improve the reliability and performance of data fetching in the dashboard by ensuring that only the latest user-initiated request is processed, and any obsolete requests are cancelled.…3 @copilot