### PR TITLE
Add artsdata ID for revert to draft condition

### DIFF
--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -1400,10 +1400,10 @@ function AddEvent() {
               .catch((error) => console.log(error));
           }
         } else if (
-          (isValuesChanged || Object.keys(activeFallbackFieldsInfo).length > 0 || duplicateId) &&
+          (isValuesChanged || Object.keys(activeFallbackFieldsInfo).length > 0 || duplicateId || artsDataId) &&
           (type === 'PUBLISH' || type === 'REVIEW')
         ) {
-          if (isValuesChanged || duplicateId) {
+          if (isValuesChanged || duplicateId || artsDataId) {
             saveAsDraftHandler(event, true, type)
               .then((id) => {
                 updateEventState({ id: eventId ?? id, calendarId, publishState })


### PR DESCRIPTION
This pull request updates the event publishing logic in the `AddEvent` page to better handle cases where an `artsDataId` is present. The main change ensures that events with an `artsDataId` are saved as drafts when publishing or reviewing, even if other conditions are not met.

**Improvements to event publishing logic:**

* Updated the conditional checks in `AddEvent.jsx` to include `artsDataId` as a trigger for saving an event as a draft when publishing or reviewing. This ensures that events with an `artsDataId` are properly handled in these workflows.