### PR TITLE
Fix null opening hours and correct contain trigger

### DIFF
--- a/src/pages/Dashboard/CreateNewPlace/CreateNewPlace.jsx
+++ b/src/pages/Dashboard/CreateNewPlace/CreateNewPlace.jsx
@@ -654,7 +654,7 @@ function CreateNewPlace() {
             ...(isDataValid(description) ? { description } : { description: {} }),
             ...(isDataValid(accessibilityNote) && { accessibilityNote }),
             ...(isDataValid(disambiguatingDescription) && { disambiguatingDescription }),
-            ...(values?.openingHours && { openingHours: { uri: urlProtocolCheck(values?.openingHours) } }),
+            openingHours: values?.openingHours?.trim() ? { uri: urlProtocolCheck(values?.openingHours?.trim()) } : null,
             ...(values?.containedInPlace && {
               containedInPlace: containedInPlaceObj,
             }),
@@ -1234,7 +1234,8 @@ function CreateNewPlace() {
               placesOptions(initialContainsPlace, user, calendarContentLanguage, sourceOptions.CMS),
             );
           }
-          if (placeData?.openingHours) initialAddedFields = initialAddedFields?.concat(formFieldNames?.OPENING_HOURS);
+          if (placeData?.openingHours?.uri)
+            initialAddedFields = initialAddedFields?.concat(formFieldNames?.OPENING_HOURS);
           if (placeData?.accessibilityNote)
             initialAddedFields = initialAddedFields?.concat(formFieldNames?.ACCESSIBILITY_NOTE_WRAP);
           form.setFieldsValue({
@@ -1362,7 +1363,7 @@ function CreateNewPlace() {
             placesOptions(initialContainsPlace, user, calendarContentLanguage, externalSourceOptions.FOOTLIGHT),
           );
         }
-        if (externalCalendarEntityData[0]?.openingHours)
+        if (externalCalendarEntityData[0]?.openingHours?.uri)
           initialAddedFields = initialAddedFields?.concat(formFieldNames?.OPENING_HOURS);
         if (externalCalendarEntityData[0]?.accessibilityNote)
           initialAddedFields = initialAddedFields?.concat(formFieldNames?.ACCESSIBILITY_NOTE_WRAP);
@@ -2409,7 +2410,7 @@ function CreateNewPlace() {
                   rules={[
                     {
                       validator: (_, value) => {
-                        if (!value || value === '') return Promise.resolve();
+                        if (!value || value.trim() === '') return Promise.resolve();
                         return urlValidator(value)
                           ? Promise.resolve()
                           : Promise.reject(new Error(t('dashboard.events.addEditEvent.validations.url')));
@@ -2427,7 +2428,8 @@ function CreateNewPlace() {
                     autoComplete="off"
                     placeholder={t('dashboard.places.createNew.addPlace.address.openingHours.placeholder')}
                     onBlur={(e) => {
-                      const normalized = urlProtocolCheck(e.target.value);
+                      const trimmed = e.target.value.trim();
+                      const normalized = urlProtocolCheck(trimmed);
                       if (normalized !== e.target.value) {
                         form.setFieldValue(formFieldNames.OPENING_HOURS, normalized);
                         form.validateFields([formFieldNames.OPENING_HOURS]);

--- a/src/pages/Dashboard/PlaceReadOnly/PlaceReadOnly.jsx
+++ b/src/pages/Dashboard/PlaceReadOnly/PlaceReadOnly.jsx
@@ -191,7 +191,7 @@ function PlaceReadOnly() {
   }, [placeId]);
 
   useEffect(() => {
-    if (placeSuccess) {
+    if (placeData) {
       if (placeData?.sameAs?.length > 0) {
         let sourceId = artsDataLinkChecker(placeData?.sameAs);
         getArtsDataPlace(sourceId);
@@ -253,7 +253,7 @@ function PlaceReadOnly() {
         );
       }
     }
-  }, [placeSuccess]);
+  }, [placeData]);
 
   return !debouncedLoading ? (
     <FeatureFlag isFeatureEnabled={featureFlags.orgPersonPlacesView}>


### PR DESCRIPTION
This pull request focuses on improving the handling and validation of the `openingHours` field in the "Create New Place" and "Place ReadOnly" components. The changes ensure that whitespace is properly trimmed, null values are handled consistently, and field validation is more robust. Additionally, there are improvements to how dependent effects are triggered in the read-only view.

**Improvements to `openingHours` handling and validation:**

* The `openingHours` field is now trimmed of whitespace before being processed, validated, or normalized, ensuring that empty or whitespace-only values are treated as null and not submitted. [[1]](diffhunk://#diff-1f976a687744892dd661fe375fcde1a7ad700d3ffffc95e2c0eec34d2df92beeL657-R657) [[2]](diffhunk://#diff-1f976a687744892dd661fe375fcde1a7ad700d3ffffc95e2c0eec34d2df92beeL2412-R2413) [[3]](diffhunk://#diff-1f976a687744892dd661fe375fcde1a7ad700d3ffffc95e2c0eec34d2df92beeL2430-R2432)
* The logic for marking the `openingHours` field as "added" now checks for the presence of a valid `uri` property, preventing empty or incomplete values from being considered. [[1]](diffhunk://#diff-1f976a687744892dd661fe375fcde1a7ad700d3ffffc95e2c0eec34d2df92beeL1237-R1238) [[2]](diffhunk://#diff-1f976a687744892dd661fe375fcde1a7ad700d3ffffc95e2c0eec34d2df92beeL1365-R1366)

**Improvements to effect dependencies in read-only view:**

* The effect in `PlaceReadOnly` that fetches additional data now depends directly on `placeData` instead of `placeSuccess`, ensuring it runs at the correct times and with the correct data. [[1]](diffhunk://#diff-c24ea32e1a40dd241c1a7b03f5dd557344450f6c2bf80c867feb314bc400bbb6L194-R194) [[2]](diffhunk://#diff-c24ea32e1a40dd241c1a7b03f5dd557344450f6c2bf80c867feb314bc400bbb6L256-R256)