### PR TITLE
Fix language discrepancy in user profile for calendars

### DIFF
--- a/src/pages/Dashboard/AddUser/AddUser.jsx
+++ b/src/pages/Dashboard/AddUser/AddUser.jsx
@@ -916,7 +916,9 @@ const AddUser = () => {
                                       name={contentLanguageBilingual({
                                         data: selectedCalendar?.name,
                                         interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
-                                        calendarContentLanguage: calendarContentLanguage,
+                                        calendarContentLanguage:
+                                          allCalendarsData?.find((cal) => cal.id === selectedCalendar?.calendarId)
+                                            ?.contentLanguage ?? calendarContentLanguage,
                                       })}
                                       role={selectedCalendar?.role}
                                       readOnly={adminCheckHandler({ calendar, user }) ? false : true}


### PR DESCRIPTION
This pull request updates the logic for determining the `calendarContentLanguage` when displaying the calendar name in the `AddUser` page. The main change ensures that the content language is dynamically retrieved from the selected calendar in `allCalendarsData`, providing more accurate localization.

**Localization improvements:**

* The `calendarContentLanguage` prop in the `contentLanguageBilingual` function is now set by looking up the selected calendar's `contentLanguage` from `allCalendarsData`, with a fallback to the existing `calendarContentLanguage` if not found. This ensures the correct content language is used for the selected calendar.