### PR TITLE
Fix language discrepancy in user profile for calendars

### DIFF
--- a/src/pages/Dashboard/AddUser/AddUser.jsx
+++ b/src/pages/Dashboard/AddUser/AddUser.jsx
@@ -916,7 +916,9 @@ const AddUser = () => {
                                       name={contentLanguageBilingual({
                                         data: selectedCalendar?.name,
                                         interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
-                                        calendarContentLanguage: calendarContentLanguage,
+                                        calendarContentLanguage:
+                                          allCalendarsData?.find((cal) => cal.id === selectedCalendar?.calendarId)
+                                            ?.contentLanguage ?? calendarContentLanguage,
                                       })}
                                       role={selectedCalendar?.role}
                                       readOnly={adminCheckHandler({ calendar, user }) ? false : true}


### PR DESCRIPTION
This pull request makes a targeted improvement to how the content language is determined for a selected calendar in the `AddUser` page. The logic now dynamically retrieves the `contentLanguage` from the latest `allCalendarsData` based on the selected calendar, ensuring more accurate and up-to-date language selection.

Enhancement to content language selection:

* In `AddUser`, the `contentLanguage` is now set by looking up the selected calendar's `contentLanguage` in `allCalendarsData`, falling back to the previous value if not found.