### PR TITLE
Fix initial loading and API trigger for ArtsData

### DIFF
--- a/src/layout/CreateMultiLingualFormItems/CreateMultiLingualFormItems.jsx
+++ b/src/layout/CreateMultiLingualFormItems/CreateMultiLingualFormItems.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { contentLanguageKeyMap } from '../../constants/contentLanguage';
 import { Form } from 'antd';
 import { useTranslation } from 'react-i18next';
@@ -52,6 +52,18 @@ const CreateMultiLingualFormItems = ({ children, ...rest }) => {
     }) || [];
 
   useWatch(fieldPathsToWatch, form);
+
+  useEffect(() => {
+    if (!data || !form) return;
+    calendarContentLanguage?.forEach((language) => {
+      const lanKey = contentLanguageKeyMap[language];
+      const content = data?.[lanKey];
+      const value = Array.isArray(content) ? content[0] : content;
+      if (value !== undefined && !form.isFieldTouched(isListContext ? [...name, lanKey] : [name, lanKey])) {
+        form.setFieldValue(isListContext ? [...name, lanKey] : [name, lanKey], value);
+      }
+    });
+  }, [data]);
 
   // Track dirty fields
   const isFieldDirty = {};

--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -238,7 +238,8 @@ function AddEvent() {
       updateEventLoading ||
       addEventLoading ||
       addImageLoading ||
-      updateEventStateLoading,
+      updateEventStateLoading ||
+      (artsDataId && !eventId && artsDataLoading),
     [
       isLoading,
       taxonomyLoading,
@@ -247,6 +248,9 @@ function AddEvent() {
       addEventLoading,
       addImageLoading,
       updateEventStateLoading,
+      artsDataId,
+      eventId,
+      artsDataLoading,
     ],
   );
 
@@ -2122,6 +2126,18 @@ function AddEvent() {
     return result;
   }
 
+  const fetchArtsDataForDisplay = (uri) => {
+    setArtsDataLoading(true);
+    loadArtsDataEventEntity({ entityId: uri })
+      .then((response) => {
+        if (response?.data?.length > 0) {
+          setArtsData(response.data[0]);
+        }
+      })
+      .catch((e) => console.error('Failed to fetch ArtsData event for display', e))
+      .finally(() => setArtsDataLoading(false));
+  };
+
   const getArtsDataEvent = () => {
     let initialAddedFields = [...addedFields];
     let importFailures = {
@@ -2466,6 +2482,15 @@ function AddEvent() {
           };
 
           data = addFields(data);
+
+          if (data.name) {
+            calendarContentLanguage.forEach((language) => {
+              const langKey = contentLanguageKeyMap[language];
+              if (data.name[langKey]) {
+                form.setFieldValue(['name', langKey], data.name[langKey]);
+              }
+            });
+          }
 
           setArtsData(data);
           setAddedFields(initialAddedFields);
@@ -2909,6 +2934,13 @@ function AddEvent() {
             form.setFieldsValue({
               multipleImagesCrop: galleryImages,
             });
+          }
+        }
+        if (eventData?.sameAs?.length > 0 && !artsDataId && !duplicateId && !hasFetchedRef.current) {
+          const artsdataUri = artsDataLinkChecker(eventData.sameAs);
+          if (artsdataUri) {
+            hasFetchedRef.current = true;
+            fetchArtsDataForDisplay(artsdataUri);
           }
         }
       } else {
@@ -3364,12 +3396,12 @@ function AddEvent() {
                       <ArtsDataInfo
                         artsDataLink={artsDataLinkChecker(artsDataLink[0]?.uri)}
                         name={contentLanguageBilingual({
-                          data: eventData?.name,
+                          data: artsData?.name,
                           interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
                           calendarContentLanguage: calendarContentLanguage,
                         })}
                         disambiguatingDescription={contentLanguageBilingual({
-                          data: eventData?.disambiguatingDescription,
+                          data: artsData?.disambiguatingDescription,
                           interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
                           calendarContentLanguage: calendarContentLanguage,
                         })}


### PR DESCRIPTION
This pull request introduces improvements to multilingual form handling and ArtsData integration in the event creation flow. The main changes ensure that multilingual fields are pre-filled more reliably, ArtsData is fetched and displayed automatically when relevant, and loading states are more accurate during data import.

**Multilingual Form Handling:**
* Added a `useEffect` in `CreateMultiLingualFormItems.jsx` to automatically set form field values from the provided `data` prop for each language, ensuring fields are pre-filled when editing or importing multilingual content.

**ArtsData Integration and Display:**
* Added the `fetchArtsDataForDisplay` function to fetch and set ArtsData details when a matching URI is present, improving the ArtsData import and display process.
* Automatically triggers ArtsData fetching when an event import contains a `sameAs` link and no ArtsData has been loaded yet, enabling seamless data enrichment.
* When ArtsData is imported, pre-fills the multilingual `name` fields in the form for all supported languages.
* Updated the display logic in the `ArtsDataInfo` component to show the imported ArtsData's `name` and `disambiguatingDescription` instead of the event's, providing more accurate information to the user.

**Loading State Improvements:**
* Improved the loading state logic to include ArtsData loading during event import, preventing user interaction until all relevant data is ready. [[1]](diffhunk://#diff-7c987cb6c339d6551d07d66dfd640b055e60e23f80f1c8a33b8034b8558b7233L241-R242) [[2]](diffhunk://#diff-7c987cb6c339d6551d07d66dfd640b055e60e23f80f1c8a33b8034b8558b7233R251-R253)