### PR TITLE
Fix main handling for organizations and people

### DIFF
--- a/src/components/Accordion/CalendarAccordion/CalendarAccordion.jsx
+++ b/src/components/Accordion/CalendarAccordion/CalendarAccordion.jsx
@@ -316,7 +316,7 @@ function CalendarAccordion(props) {
         </Form.Item>
         <Form.Item
           name={['organizers', selectedCalendarId]}
-          label={t('dashboard.organization.organization')}
+          label={t('dashboard.organization.organizations')}
           hidden={
             (readOnly && selectedOrganizers?.length === 0) ||
             (calendarId !== selectedCalendarId && selectedOrganizers?.length === 0)

--- a/src/utils/formInitialValueHandler.js
+++ b/src/utils/formInitialValueHandler.js
@@ -33,12 +33,14 @@ export const formInitialValueHandler = (
 
     case formTypes.IMAGE:
       if (Array.isArray(initialData) && initialData.length > 0) {
+        const mainImage = initialData.find((image) => image?.isMain);
+        if (!mainImage) break;
         return [
           {
-            uid: initialData[0]?.original?.entityId,
-            name: initialData[0]?.original?.entityId,
+            uid: mainImage?.original?.entityId,
+            name: mainImage?.original?.entityId,
             status: 'done',
-            url: initialData[0]?.original?.uri,
+            url: mainImage?.original?.uri,
           },
         ];
       } else if (initialData?.original?.uri) {


### PR DESCRIPTION
This pull request updates the logic for handling initial image values in forms. The main change is that the code now selects the image marked as the "main" image instead of always using the first image in the list.

Improvements to image selection logic:

* In the `formInitialValueHandler` function in `src/utils/formInitialValueHandler.js`, updated the `formTypes.IMAGE` case to find and use the image with `isMain` set, ensuring the main image is used for form initialization instead of the first image in the array.