### PR TITLE
Fix main handling and typo for organizations and people

### DIFF
--- a/src/components/Accordion/CalendarAccordion/CalendarAccordion.jsx
+++ b/src/components/Accordion/CalendarAccordion/CalendarAccordion.jsx
@@ -316,7 +316,7 @@ function CalendarAccordion(props) {
         </Form.Item>
         <Form.Item
           name={['organizers', selectedCalendarId]}
-          label={t('dashboard.organization.organization')}
+          label={t('dashboard.organization.organizations')}
           hidden={
             (readOnly && selectedOrganizers?.length === 0) ||
             (calendarId !== selectedCalendarId && selectedOrganizers?.length === 0)

--- a/src/utils/formInitialValueHandler.js
+++ b/src/utils/formInitialValueHandler.js
@@ -33,12 +33,14 @@ export const formInitialValueHandler = (
 
     case formTypes.IMAGE:
       if (Array.isArray(initialData) && initialData.length > 0) {
+        const mainImage = initialData.find((image) => image?.isMain);
+        if (!mainImage) break;
         return [
           {
-            uid: initialData[0]?.original?.entityId,
-            name: initialData[0]?.original?.entityId,
+            uid: mainImage?.original?.entityId,
+            name: mainImage?.original?.entityId,
             status: 'done',
-            url: initialData[0]?.original?.uri,
+            url: mainImage?.original?.uri,
           },
         ];
       } else if (initialData?.original?.uri) {


### PR DESCRIPTION
This pull request introduces a small UI text update and an improvement to how the main image is selected in form initial values. The most important changes are:

**UI Text Update:**
* Changed the label for organizers in `CalendarAccordion` from singular to plural for improved clarity (`label={t('dashboard.organization.organization')}` → `label={t('dashboard.organization.organizations')}`) (`src/components/Accordion/CalendarAccordion/CalendarAccordion.jsx`)

[Change request](https://github.com/culturecreates/footlight-app/issues/2115#issuecomment-4381804555) from Caitlin for the same 

**Form Initialization Logic:**
* Updated the image form initial value handler to select the image marked as `isMain` (if present) instead of always choosing the first image. This ensures the main image is prioritized when initializing form values (`src/utils/formInitialValueHandler.js`)