### PR TITLE
Add isCustom check for modal open state update

### DIFF
--- a/src/components/RecurringEvents/RecurringEvents.jsx
+++ b/src/components/RecurringEvents/RecurringEvents.jsx
@@ -57,7 +57,7 @@ const RecurringEvents = function ({
   useEffect(() => {
     if (!frequency) return;
 
-    if (frequency === 'CUSTOM' && !isModalVisible && !initialRenderRef.current) setIsModalVisible(true);
+    if (frequency === 'CUSTOM' && !isModalVisible && !initialRenderRef.current && !isCustom) setIsModalVisible(true);
 
     initialRenderRef.current = false;
   }, [frequency]);


### PR DESCRIPTION
This pull request introduces a small but important fix to the logic that determines when the custom modal should be shown in the `RecurringEvents` component. The change ensures that the modal is not shown automatically if the event is already marked as custom.

* Prevents the custom modal from being shown if the event is already custom by adding a check for `!isCustom` in the effect that handles frequency changes in `RecurringEvents.jsx`.