### PR TITLE
Fix padding for search pages

### DIFF
--- a/src/layout/CreateNewEntity/NewEntityLayout.jsx
+++ b/src/layout/CreateNewEntity/NewEntityLayout.jsx
@@ -15,7 +15,7 @@ const NewEntityLayout = ({ children, heading, text, entityName, searchHeading })
   return (
     <FeatureFlag isFeatureEnabled={featureFlags.editScreenPeoplePlaceOrganization}>
       <Row className="create-new-entity-page" gutter={[0, 24]}>
-        <Col span={24}>
+        <Col span={24} className="create-new-entity-sticky-header">
           <div className="button-container">
             <Button type="link" onClick={() => navigate(-1)} data-cy="button-breadcrumb-back-to-previous-page">
               <LeftOutlined style={{ fontSize: '12px', paddingRight: '5px' }} />

--- a/src/layout/CreateNewEntity/createNew.css
+++ b/src/layout/CreateNewEntity/createNew.css
@@ -1,3 +1,16 @@
+.create-new-entity-page .create-new-entity-sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #f9faff;
+  margin-left: -32px;
+  margin-right: -32px;
+  padding-left: 32px;
+  padding-right: 32px;
+  padding-top: 32px;
+  padding-bottom: 8px;
+}
+
 .create-new-entity-page .button-container .ant-btn {
   color: #0f0e98;
   border: none;
@@ -43,6 +56,14 @@
 }
 
 @media (max-width: 768px) {
+  .create-new-entity-page .create-new-entity-sticky-header {
+    margin-left: -16px;
+    margin-right: -16px;
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 32px;
+  }
+
   .create-new-entity-page .content .text {
     font-weight: 700;
   }

--- a/src/pages/Dashboard/SelectTaxonomyType/SelectTaxonomyType.jsx
+++ b/src/pages/Dashboard/SelectTaxonomyType/SelectTaxonomyType.jsx
@@ -77,7 +77,7 @@ const SelectTaxonomyType = () => {
 
   return (
     <div className="select-taxonomy-type-wrapper">
-      <Row>
+      <Row className="select-taxonomy-type-sticky-header">
         <Col span={24}>
           <div className="button-container">
             <Button type="link" onClick={() => navigate(-1)} data-cy="button-taxonomy-back-to-previous">

--- a/src/pages/Dashboard/SelectTaxonomyType/selectTaxonomyType.css
+++ b/src/pages/Dashboard/SelectTaxonomyType/selectTaxonomyType.css
@@ -1,3 +1,16 @@
+.select-taxonomy-type-wrapper .select-taxonomy-type-sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #f9faff;
+  margin-left: -32px;
+  margin-right: -32px;
+  padding-left: 32px;
+  padding-right: 32px;
+  padding-top: 32px;
+  padding-bottom: 8px;
+}
+
 .select-taxonomy-type-wrapper .button-container .ant-btn {
   color: #0f0e98;
   border: none;
@@ -12,7 +25,6 @@
 .select-taxonomy-type-wrapper .heading {
   font-size: 34px;
   font-weight: 700;
-  padding-top: 16px;
 }
 
 .select-taxonomy-type-wrapper .ant-form-item-label > label {
@@ -76,5 +88,15 @@
   .select-taxonomy-type-wrapper .info-message,
   .select-taxonomy-type-wrapper .ant-form-item-explain-error {
     font-size: 12px;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .select-taxonomy-type-wrapper .select-taxonomy-type-sticky-header {
+    margin-left: -16px;
+    margin-right: -16px;
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 32px;
   }
 }


### PR DESCRIPTION
This pull request improves the user experience on the "Create New Entity" and "Select Taxonomy Type" pages by making the header sections sticky, ensuring that navigation and context remain visible as users scroll. The changes include new CSS classes and updates to the component structure to support sticky headers, with responsive design adjustments for mobile devices.

**Sticky header implementation:**

* Added the `create-new-entity-sticky-header` class to the header `Col` in `NewEntityLayout.jsx` and defined corresponding CSS to make the header sticky, with appropriate padding, margins, and background color for desktop and mobile views (`src/layout/CreateNewEntity/NewEntityLayout.jsx`, `src/layout/CreateNewEntity/createNew.css`). [[1]](diffhunk://#diff-870d7303f87f6384329fbd42d5929de3da2ad8ea5d6e4ba0b5bb6243b33c6242L18-R18) [[2]](diffhunk://#diff-2daa83ce667c98c991de987a3edc2f9bea30618c0b257b84f64744d6bc3ab858R1-R13) [[3]](diffhunk://#diff-2daa83ce667c98c991de987a3edc2f9bea30618c0b257b84f64744d6bc3ab858R59-R66)
* Added the `select-taxonomy-type-sticky-header` class to the header `Row` in `SelectTaxonomyType.jsx` and defined corresponding CSS for sticky positioning and responsive adjustments (`src/pages/Dashboard/SelectTaxonomyType/SelectTaxonomyType.jsx`, `src/pages/Dashboard/SelectTaxonomyType/selectTaxonomyType.css`). [[1]](diffhunk://#diff-f5f620972f75b40af5de30a2877b7768ea784c4b192e3806a383c8b123778510L80-R80) [[2]](diffhunk://#diff-ac86561e63fb498f182c90caba97f59a2f2ec0b054ff3b53acfa39740b4baa92R1-R13) [[3]](diffhunk://#diff-ac86561e63fb498f182c90caba97f59a2f2ec0b054ff3b53acfa39740b4baa92R93-R102)

**Minor style adjustments:**

* Removed unnecessary top padding from the `.heading` class in `selectTaxonomyType.css` for a cleaner appearance with the new sticky header (`src/pages/Dashboard/SelectTaxonomyType/selectTaxonomyType.css`).