### PR TITLE
Fix shared taxonomy reconciliation for listing page filters

### DIFF
--- a/src/pages/Dashboard/Events/Events.jsx
+++ b/src/pages/Dashboard/Events/Events.jsx
@@ -68,6 +68,7 @@ import {
   IMPORT_ACTION_KEY,
   REPORT_ACTION_KEY,
 } from '../../../constants/entitiesClass';
+import { reconcileTaxonomyFilters } from '../../../utils/taxonomyFilterReconciliation';
 
 const { useBreakpoint } = Grid;
 const standardTaxonomyMaps = [
@@ -291,7 +292,32 @@ function Events() {
   );
 
   const calendar = getCurrentCalendarDetailsFromUserDetails(user, calendarId);
-  let customFilters = [...(currentCalendarData?.filterPersonalization?.events ?? [])];
+  let customFilters = currentCalendarData?.filterPersonalization?.events ?? [];
+
+  useEffect(() => {
+    if (!allTaxonomyData?.data?.length) return;
+
+    const {
+      reconciledTaxonomyFilter,
+      reconciledStandardTaxonomyFilter,
+      isTaxonomyFilterChanged,
+      isStandardTaxonomyFilterChanged,
+    } = reconcileTaxonomyFilters({
+      taxonomyFilter,
+      standardTaxonomyFilter,
+      taxonomies: allTaxonomyData?.data,
+      customFilters,
+    });
+
+    if (isTaxonomyFilterChanged) {
+      setTaxonomyFilter(reconciledTaxonomyFilter);
+    }
+
+    if (isStandardTaxonomyFilterChanged) {
+      setStandardTaxonomyFilter(reconciledStandardTaxonomyFilter);
+    }
+  }, [allTaxonomyData?.data, customFilters, taxonomyFilter, standardTaxonomyFilter]);
+
   const dateTypeSelector = (dates) => {
     if (dates?.length == 2) {
       if (dates?.every((date) => date === 'any')) return dateFilterTypes.ALL_EVENTS;

--- a/src/pages/Dashboard/Organizations/Organizations.jsx
+++ b/src/pages/Dashboard/Organizations/Organizations.jsx
@@ -47,6 +47,7 @@ import SearchableCheckbox from '../../../components/Filter/SearchableCheckbox';
 import { entitiesClass } from '../../../constants/entitiesClass';
 import EntityReports from '../../../components/EntityReports/EntityReports';
 import ReadOnlyProtectedComponent from '../../../layout/ReadOnlyProtectedComponent';
+import { reconcileTaxonomyFilters } from '../../../utils/taxonomyFilterReconciliation';
 
 const { useBreakpoint } = Grid;
 
@@ -147,6 +148,30 @@ function Organizations() {
 
   let customFilters = currentCalendarData?.filterPersonalization?.organization ?? [];
 
+  useEffect(() => {
+    if (!allTaxonomyData?.data?.length) return;
+
+    const {
+      reconciledTaxonomyFilter,
+      reconciledStandardTaxonomyFilter,
+      isTaxonomyFilterChanged,
+      isStandardTaxonomyFilterChanged,
+    } = reconcileTaxonomyFilters({
+      taxonomyFilter,
+      standardTaxonomyFilter,
+      taxonomies: allTaxonomyData?.data,
+      customFilters,
+    });
+
+    if (isTaxonomyFilterChanged) {
+      setTaxonomyFilter(reconciledTaxonomyFilter);
+    }
+
+    if (isStandardTaxonomyFilterChanged) {
+      setStandardTaxonomyFilter(reconciledStandardTaxonomyFilter);
+    }
+  }, [allTaxonomyData?.data, customFilters, taxonomyFilter, standardTaxonomyFilter]);
+
   const deleteOrganizationHandler = (organizationId) => {
     getDependencyDetails({ ids: organizationId, calendarId })
       .unwrap()
@@ -222,6 +247,7 @@ function Organizations() {
       order: sortOrder?.ASC,
     });
     setTaxonomyFilter({});
+    setStandardTaxonomyFilter({});
     setUserFilter([]);
     setOrganizationIdFilter([]);
     setPageNumber(1);
@@ -661,6 +687,7 @@ function Organizations() {
               <Col>
                 {(filter?.order === sortOrder?.DESC ||
                   Object.keys(taxonomyFilter)?.length > 0 ||
+                  Object.keys(standardTaxonomyFilter)?.length > 0 ||
                   userFilter.length > 0 ||
                   organizationIdFilter.length > 0 ||
                   filter?.sort != sortByOptionsOrgsPlacesPerson[0]?.key) && (

--- a/src/pages/Dashboard/People/People.jsx
+++ b/src/pages/Dashboard/People/People.jsx
@@ -46,6 +46,7 @@ import { removeObjectArrayDuplicates } from '../../../utils/removeObjectArrayDup
 import { entitiesClass } from '../../../constants/entitiesClass';
 import EntityReports from '../../../components/EntityReports/EntityReports';
 import ReadOnlyProtectedComponent from '../../../layout/ReadOnlyProtectedComponent';
+import { reconcileTaxonomyFilters } from '../../../utils/taxonomyFilterReconciliation';
 
 const { useBreakpoint } = Grid;
 const standardTaxonomyMaps = [
@@ -149,6 +150,30 @@ function People() {
   const calendar = getCurrentCalendarDetailsFromUserDetails(user, calendarId);
 
   let customFilters = currentCalendarData?.filterPersonalization?.people ?? [];
+
+  useEffect(() => {
+    if (!allTaxonomyData?.data?.length) return;
+
+    const {
+      reconciledTaxonomyFilter,
+      reconciledStandardTaxonomyFilter,
+      isTaxonomyFilterChanged,
+      isStandardTaxonomyFilterChanged,
+    } = reconcileTaxonomyFilters({
+      taxonomyFilter,
+      standardTaxonomyFilter,
+      taxonomies: allTaxonomyData?.data,
+      customFilters,
+    });
+
+    if (isTaxonomyFilterChanged) {
+      setTaxonomyFilter(reconciledTaxonomyFilter);
+    }
+
+    if (isStandardTaxonomyFilterChanged) {
+      setStandardTaxonomyFilter(reconciledStandardTaxonomyFilter);
+    }
+  }, [allTaxonomyData?.data, customFilters, taxonomyFilter, standardTaxonomyFilter]);
 
   const deletePersonHandler = (personId) => {
     getDependencyDetails({ ids: personId, calendarId })

--- a/src/pages/Dashboard/Places/Places.jsx
+++ b/src/pages/Dashboard/Places/Places.jsx
@@ -46,6 +46,7 @@ import { SEARCH_DELAY } from '../../../constants/search';
 import { entitiesClass } from '../../../constants/entitiesClass';
 import EntityReports from '../../../components/EntityReports/EntityReports';
 import ReadOnlyProtectedComponent from '../../../layout/ReadOnlyProtectedComponent';
+import { reconcileTaxonomyFilters } from '../../../utils/taxonomyFilterReconciliation';
 
 const { useBreakpoint } = Grid;
 const standardTaxonomyMaps = [
@@ -164,6 +165,30 @@ function Places() {
 
   let customFilters = currentCalendarData?.filterPersonalization?.places ?? [];
 
+  useEffect(() => {
+    if (!allTaxonomyData?.data?.length) return;
+
+    const {
+      reconciledTaxonomyFilter,
+      reconciledStandardTaxonomyFilter,
+      isTaxonomyFilterChanged,
+      isStandardTaxonomyFilterChanged,
+    } = reconcileTaxonomyFilters({
+      taxonomyFilter,
+      standardTaxonomyFilter,
+      taxonomies: allTaxonomyData?.data,
+      customFilters,
+    });
+
+    if (isTaxonomyFilterChanged) {
+      setTaxonomyFilter(reconciledTaxonomyFilter);
+    }
+
+    if (isStandardTaxonomyFilterChanged) {
+      setStandardTaxonomyFilter(reconciledStandardTaxonomyFilter);
+    }
+  }, [allTaxonomyData?.data, customFilters, taxonomyFilter, standardTaxonomyFilter]);
+
   const deletePlaceHandler = (placeId) => {
     getDependencyDetails({ ids: placeId, calendarId })
       .unwrap()
@@ -252,8 +277,8 @@ function Places() {
     sessionStorage.removeItem('placesPage');
     sessionStorage.removeItem('placesSearchQuery');
     sessionStorage.removeItem('placeOrder');
-    sessionStorage.removeItem('taxonomyFilter');
-    sessionStorage.removeItem('standardTaxonomyFilter');
+    sessionStorage.removeItem('placeTaxonomyFilter');
+    sessionStorage.removeItem('standardPlaceTaxonomyFilter');
     sessionStorage.removeItem('placeSortBy');
   };
 

--- a/src/utils/taxonomyFilterReconciliation.js
+++ b/src/utils/taxonomyFilterReconciliation.js
@@ -1,0 +1,109 @@
+const normalizeConceptIds = (concepts = []) => {
+  if (!Array.isArray(concepts)) return [];
+
+  const uniqueConceptIds = [];
+  const seen = new Set();
+
+  concepts.forEach((concept) => {
+    const conceptId = concept?.id ?? concept;
+    if (conceptId === null || conceptId === undefined) return;
+
+    const normalizedConceptId = String(conceptId);
+    if (seen.has(normalizedConceptId)) return;
+
+    seen.add(normalizedConceptId);
+    uniqueConceptIds.push(normalizedConceptId);
+  });
+
+  return uniqueConceptIds;
+};
+
+const buildAllowedTaxonomySelections = ({ taxonomies = [], customFilters = [] }) => {
+  const customFilterIds = new Set((customFilters ?? []).map((id) => String(id)));
+
+  const dynamicTaxonomyConcepts = new Map();
+  const standardTaxonomyConcepts = new Map();
+
+  (taxonomies ?? []).forEach((taxonomy) => {
+    if (!taxonomy?.id || !customFilterIds.has(String(taxonomy.id))) return;
+
+    const conceptIds = normalizeConceptIds(taxonomy?.concept);
+
+    if (taxonomy?.isDynamicField) {
+      dynamicTaxonomyConcepts.set(String(taxonomy.id), new Set(conceptIds));
+      return;
+    }
+
+    if (taxonomy?.mappedToField) {
+      standardTaxonomyConcepts.set(String(taxonomy.mappedToField), new Set(conceptIds));
+    }
+  });
+
+  return {
+    dynamicTaxonomyConcepts,
+    standardTaxonomyConcepts,
+  };
+};
+
+const reconcileFilterByAllowedConcepts = (selectedFilter = {}, allowedTaxonomyConceptMap = new Map()) => {
+  const reconciledFilter = {};
+  let changed = false;
+
+  Object.entries(selectedFilter ?? {}).forEach(([taxonomyKey, selectedConceptIds]) => {
+    const normalizedTaxonomyKey = String(taxonomyKey);
+    const allowedConceptIds = allowedTaxonomyConceptMap.get(normalizedTaxonomyKey);
+
+    if (!allowedConceptIds) {
+      changed = true;
+      return;
+    }
+
+    const normalizedSelectedConceptIds = normalizeConceptIds(selectedConceptIds);
+    const validConceptIds = normalizedSelectedConceptIds.filter((conceptId) => allowedConceptIds.has(conceptId));
+
+    if (validConceptIds.length === 0) {
+      changed = true;
+      return;
+    }
+
+    if (validConceptIds.length !== normalizedSelectedConceptIds.length) {
+      changed = true;
+    }
+
+    reconciledFilter[normalizedTaxonomyKey] = validConceptIds;
+  });
+
+  if (Object.keys(reconciledFilter).length !== Object.keys(selectedFilter ?? {}).length) {
+    changed = true;
+  }
+
+  return {
+    reconciledFilter,
+    changed,
+  };
+};
+
+export const reconcileTaxonomyFilters = ({
+  taxonomyFilter = {},
+  standardTaxonomyFilter = {},
+  taxonomies = [],
+  customFilters = [],
+}) => {
+  const { dynamicTaxonomyConcepts, standardTaxonomyConcepts } = buildAllowedTaxonomySelections({
+    taxonomies,
+    customFilters,
+  });
+
+  const { reconciledFilter: reconciledTaxonomyFilter, changed: isTaxonomyFilterChanged } =
+    reconcileFilterByAllowedConcepts(taxonomyFilter, dynamicTaxonomyConcepts);
+
+  const { reconciledFilter: reconciledStandardTaxonomyFilter, changed: isStandardTaxonomyFilterChanged } =
+    reconcileFilterByAllowedConcepts(standardTaxonomyFilter, standardTaxonomyConcepts);
+
+  return {
+    reconciledTaxonomyFilter,
+    reconciledStandardTaxonomyFilter,
+    isTaxonomyFilterChanged,
+    isStandardTaxonomyFilterChanged,
+  };
+};


### PR DESCRIPTION
This pull request introduces a new utility, `reconcileTaxonomyFilters`, to ensure that taxonomy filters in the dashboard pages remain consistent with the available taxonomy data and user personalization. The utility is integrated into the Events, Organizations, People, and Places dashboard pages, automatically reconciling and updating filters when underlying taxonomy data changes. Additionally, some minor cleanups and improvements are made to filter reset and session storage logic.

**Taxonomy filter reconciliation improvements:**

* Added a new utility, `reconcileTaxonomyFilters`, in `src/utils/taxonomyFilterReconciliation.js` to normalize, validate, and reconcile selected taxonomy and standard taxonomy filters based on available taxonomies and user customizations. This ensures only valid concept IDs are retained in filters, and detects when filters need to be updated.
* Integrated `reconcileTaxonomyFilters` into the `Events.jsx`, `Organizations.jsx`, `People.jsx`, and `Places.jsx` dashboard pages, using a `useEffect` hook to automatically reconcile and update taxonomy filters whenever taxonomy data or filters change. [[1]](diffhunk://#diff-53e1775d15b31ee41a29af44278114f697491f4f47c6cfdca84805257329bd55R71) [[2]](diffhunk://#diff-53e1775d15b31ee41a29af44278114f697491f4f47c6cfdca84805257329bd55L294-R320) [[3]](diffhunk://#diff-eb021b9450dc17f8965a2713103daff02ae66b0f805061a68b124fdf0727f16fR50) [[4]](diffhunk://#diff-eb021b9450dc17f8965a2713103daff02ae66b0f805061a68b124fdf0727f16fR151-R174) [[5]](diffhunk://#diff-036bec836d907bbf62f5e0ce53ea5b9570b545192b56585b4b553a45a0c21be4R49) [[6]](diffhunk://#diff-036bec836d907bbf62f5e0ce53ea5b9570b545192b56585b4b553a45a0c21be4R154-R177) [[7]](diffhunk://#diff-0320145f9c75fa4863b19f95cf75b9cfae71e153b709613678bf9aac490a3852R49) [[8]](diffhunk://#diff-0320145f9c75fa4863b19f95cf75b9cfae71e153b709613678bf9aac490a3852R168-R191)

**Filter reset and UI improvements:**

* Updated filter reset logic in `Organizations.jsx` to clear both `taxonomyFilter` and `standardTaxonomyFilter` when resetting filters.
* Improved the filter UI in `Organizations.jsx` to consider `standardTaxonomyFilter` when determining if filters are active.
* Adjusted session storage key names for taxonomy filters in `Places.jsx` to be more specific and consistent, changing from generic keys to `placeTaxonomyFilter` and `standardPlaceTaxonomyFilter`.