### PR TITLE
Fix artsdata and datafeed tag and URI redirection

### DIFF
--- a/src/components/List/SelectionItem/SelectionItem.jsx
+++ b/src/components/List/SelectionItem/SelectionItem.jsx
@@ -17,6 +17,7 @@ import { PathName } from '../../../constants/pathName.js';
 import { useNavigate, useParams } from 'react-router-dom';
 import Link from 'antd/lib/typography/Link.js';
 import { truncateText } from '../../../utils/stringManipulations.js';
+import { isArtsdataUri } from '../../../utils/artsDataLinkChecker.js';
 function SelectionItem(props) {
   const {
     icon,
@@ -68,6 +69,10 @@ function SelectionItem(props) {
     ? t('common.forms.languageLiterals.unKnownLanguagePromptText')
     : t('common.forms.languageLiterals.knownLanguagePromptText');
 
+  const externalSourceLinkLabel = isArtsdataUri(artsDataLink)
+    ? t('dashboard.events.createNew.search.linkText')
+    : t('dashboard.events.createNew.search.datafeed');
+
   const routinghandler = (e) => {
     const type = onClickHandle?.entityType;
     const id = onClickHandle?.entityId;
@@ -100,7 +105,7 @@ function SelectionItem(props) {
             <ArtsDataLink data-cy="artsdata-link-tag">
               <Link href={artsDataLink} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}>
                 <div style={{ display: 'flex', gap: '7px', color: '#0f0e98' }}>
-                  <span style={{ textDecoration: 'underline' }}>Artsdata</span>
+                  <span style={{ textDecoration: 'underline' }}>{externalSourceLinkLabel}</span>
                   <LinkOutlined style={{ display: 'grid', placeContent: 'center', color: '#0f0e98' }} />
                 </div>
               </Link>

--- a/src/components/List/SelectionItem/SelectionItem.jsx
+++ b/src/components/List/SelectionItem/SelectionItem.jsx
@@ -69,7 +69,7 @@ function SelectionItem(props) {
     ? t('common.forms.languageLiterals.unKnownLanguagePromptText')
     : t('common.forms.languageLiterals.knownLanguagePromptText');
 
-  const externalSourceLinkLabel = isArtsdataUri(artsDataLink)
+  const externalSourceLinkLabel = artsDataLink && isArtsdataUri(artsDataLink)
     ? t('dashboard.events.createNew.search.linkText')
     : t('dashboard.events.createNew.search.datafeed');
 

--- a/src/components/Select/selectOption.settings.js
+++ b/src/components/Select/selectOption.settings.js
@@ -5,6 +5,7 @@ import { languageFallbackStatusCreator } from '../../utils/languageFallbackStatu
 import { isDataValid } from '../../utils/MultiLingualFormItemSupportFunctions';
 import SelectionItem from '../List/SelectionItem';
 import { EnvironmentOutlined } from '@ant-design/icons';
+import { createArtsDataLink } from '../../utils/artsDataLinkChecker';
 
 export const taxonomyOptions = (data, user, mappedToField, calendarContentLanguage) => {
   let fieldData = data?.data?.filter((taxonomy) => taxonomy?.mappedToField === mappedToField);
@@ -70,7 +71,7 @@ export const placesOptions = (
               : typeof place?.description === 'string' && place?.description
           }
           calendarContentLanguage={calendarContentLanguage}
-          artsDataLink={place?.uri}
+          artsDataLink={createArtsDataLink(place?.uri)}
           showExternalSourceLink={true}
         />
       ),

--- a/src/components/TreeSelectOption/treeSelectOption.settings.js
+++ b/src/components/TreeSelectOption/treeSelectOption.settings.js
@@ -7,6 +7,7 @@ import { sourceOptions } from '../../constants/sourceOptions';
 import { languageFallbackStatusCreator } from '../../utils/languageFallbackStatusCreator';
 import { contentLanguageKeyMap } from '../../constants/contentLanguage';
 import { isDataValid } from '../../utils/MultiLingualFormItemSupportFunctions';
+import { createArtsDataLink } from '../../utils/artsDataLinkChecker';
 
 const handleMultilevelTreeSelect = (children, user, calendarContentLanguage, parentLabel) => {
   return children?.map((child) => {
@@ -143,7 +144,7 @@ export const treeEntitiesOption = (
               : typeof entity?.description === 'string' && entity?.description
           }
           calendarContentLanguage={calendarContentLanguage}
-          artsDataLink={entity?.uri}
+          artsDataLink={createArtsDataLink(entity?.uri)}
           showExternalSourceLink={true}
         />
       ),

--- a/src/pages/Dashboard/SearchOrganizations/SearchOrganizations.jsx
+++ b/src/pages/Dashboard/SearchOrganizations/SearchOrganizations.jsx
@@ -12,7 +12,7 @@ import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { getUserDetails } from '../../../redux/reducer/userSlice';
 import { contentLanguageBilingual } from '../../../utils/bilingual';
-import { artsDataLinkChecker, createArtsDataLink, isArtsdataUri } from '../../../utils/artsDataLinkChecker';
+import { createArtsDataLink, isArtsdataUri } from '../../../utils/artsDataLinkChecker';
 import CreateEntityButton from '../../../components/Card/Common/CreateEntityButton';
 import { PathName } from '../../../constants/pathName';
 import { Popover } from 'antd';
@@ -304,7 +304,7 @@ function SearchOrganizations() {
                                 calendarContentLanguage: calendarContentLanguage,
                               })}
                               isTransparent={organizer?.logo?.isTransparent ?? false}
-                              artsDataLink={artsDataLinkChecker(organizer?.uri)}
+                              artsDataLink={createArtsDataLink(organizer?.uri)}
                               Logo={
                                 organizer.logo ? (
                                   <img src={organizer.logo?.thumbnail?.uri} data-cy={`img-entity-logo-${index}`} />
@@ -374,7 +374,7 @@ function SearchOrganizations() {
                                 calendarContentLanguage: calendarContentLanguage,
                               })}
                               description={organizer?.description}
-                              artsDataLink={organizer?.uri}
+                              artsDataLink={createArtsDataLink(organizer?.uri)}
                               Logo={organizer.logo ? <img src={organizer?.logo?.thumbnail?.uri} /> : <Logo />}
                               linkText={
                                 isArtsdataUri(organizer?.uri)

--- a/src/pages/Dashboard/SearchPerson/SearchPerson.jsx
+++ b/src/pages/Dashboard/SearchPerson/SearchPerson.jsx
@@ -12,7 +12,7 @@ import { PathName } from '../../../constants/pathName';
 import NewEntityLayout from '../../../layout/CreateNewEntity/NewEntityLayout';
 import { getUserDetails } from '../../../redux/reducer/userSlice';
 import { useGetEntitiesQuery, useLazyGetEntitiesQuery } from '../../../services/entities';
-import { artsDataLinkChecker, createArtsDataLink, isArtsdataUri } from '../../../utils/artsDataLinkChecker';
+import { createArtsDataLink, isArtsdataUri } from '../../../utils/artsDataLinkChecker';
 import { UserOutlined } from '@ant-design/icons';
 import { contentLanguageBilingual } from '../../../utils/bilingual';
 import './searchPerson.css';
@@ -232,7 +232,7 @@ function SearchPerson() {
                             interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
                             calendarContentLanguage: calendarContentLanguage,
                           })}
-                          artsDataLink={artsDataLinkChecker(person?.uri)}
+                          artsDataLink={createArtsDataLink(person?.uri)}
                           Logo={
                             person.logo ? (
                               person.logo?.thumbnail?.uri
@@ -303,7 +303,7 @@ function SearchPerson() {
                                 interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
                                 calendarContentLanguage: calendarContentLanguage,
                               })}
-                              artsDataLink={artsDataLinkChecker(person?.uri)}
+                              artsDataLink={createArtsDataLink(person?.uri)}
                               Logo={
                                 person.logo ? (
                                   person.logo?.thumbnail?.uri

--- a/src/pages/Dashboard/SearchPlaces/SearchPlaces.jsx
+++ b/src/pages/Dashboard/SearchPlaces/SearchPlaces.jsx
@@ -10,7 +10,7 @@ import EventsSearch from '../../../components/Search/Events/EventsSearch';
 import { PathName } from '../../../constants/pathName';
 import NewEntityLayout from '../../../layout/CreateNewEntity/NewEntityLayout';
 import { getUserDetails } from '../../../redux/reducer/userSlice';
-import { artsDataLinkChecker, createArtsDataLink, isArtsdataUri } from '../../../utils/artsDataLinkChecker';
+import { createArtsDataLink, isArtsdataUri } from '../../../utils/artsDataLinkChecker';
 import { contentLanguageBilingual } from '../../../utils/bilingual';
 import { EnvironmentOutlined } from '@ant-design/icons';
 import './searchPlaces.css';
@@ -232,7 +232,7 @@ function SearchPlaces() {
                             interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
                             calendarContentLanguage: calendarContentLanguage,
                           })}
-                          artsDataLink={artsDataLinkChecker(place?.uri)}
+                          artsDataLink={createArtsDataLink(place?.uri)}
                           Logo={
                             place.logo ? (
                               place.logo?.thumbnail?.uri
@@ -303,7 +303,7 @@ function SearchPlaces() {
                                 interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
                                 calendarContentLanguage: calendarContentLanguage,
                               })}
-                              artsDataLink={artsDataLinkChecker(place?.uri)}
+                              artsDataLink={createArtsDataLink(place?.uri)}
                               Logo={
                                 place.logo ? (
                                   place.logo?.thumbnail?.uri


### PR DESCRIPTION

This pull request standardizes how external Artsdata links are generated and displayed across several components. The main change is the consistent use of the `createArtsDataLink` utility function instead of directly using URIs or the older `artsDataLinkChecker`, which improves reliability and maintainability. Additionally, the display label for external source links is now dynamic, using a helper to determine the appropriate text based on the link type.

**Artsdata link handling improvements:**

* Replaced all usages of `artsDataLinkChecker` and direct URIs with the `createArtsDataLink` function when passing `artsDataLink` props to components such as `SelectionItem` and various entity search/list components. This ensures consistent formatting of external links throughout the application. [[1]](diffhunk://#diff-e07e6e59c0d52945d209be76a876a752ffbacc61e195fc0c2835b34ac4c28efdL307-R307) [[2]](diffhunk://#diff-e07e6e59c0d52945d209be76a876a752ffbacc61e195fc0c2835b34ac4c28efdL377-R377) [[3]](diffhunk://#diff-e699ccf174ac04791d97d89ce6524ece437a5dab9a13e7154c236106d3141895L235-R235) [[4]](diffhunk://#diff-e699ccf174ac04791d97d89ce6524ece437a5dab9a13e7154c236106d3141895L306-R306) [[5]](diffhunk://#diff-fcf235711126846b08263b6efecbcaf793d859e89f47aa1380c1e46b40d26f80L235-R235) [[6]](diffhunk://#diff-fcf235711126846b08263b6efecbcaf793d859e89f47aa1380c1e46b40d26f80L306-R306) [[7]](diffhunk://#diff-0a98c34f99d04a377fcee837f05628304969462e062f67a48d7903d7cb2aa370L73-R74) [[8]](diffhunk://#diff-7287b51d4b35aae0f1f246c37417e75bd09257f5bf1fd499396cdb47416d7a82L146-R147)

* Updated imports to remove unused or deprecated link checker utilities, keeping only `createArtsDataLink` and `isArtsdataUri` where needed. [[1]](diffhunk://#diff-e07e6e59c0d52945d209be76a876a752ffbacc61e195fc0c2835b34ac4c28efdL15-R15) [[2]](diffhunk://#diff-e699ccf174ac04791d97d89ce6524ece437a5dab9a13e7154c236106d3141895L15-R15) [[3]](diffhunk://#diff-fcf235711126846b08263b6efecbcaf793d859e89f47aa1380c1e46b40d26f80L13-R13) [[4]](diffhunk://#diff-0a98c34f99d04a377fcee837f05628304969462e062f67a48d7903d7cb2aa370R8) [[5]](diffhunk://#diff-7287b51d4b35aae0f1f246c37417e75bd09257f5bf1fd499396cdb47416d7a82R10) [[6]](diffhunk://#diff-bf03dfb2a1d08bc13788fc4c8a0dfafe0f2347590b06a2e19dba95ed43a2e7ebR20)

**UI/UX enhancements for external links:**

* Modified `SelectionItem` to display a dynamic label for external source links (e.g., "Artsdata" or "Datafeed") based on the link type, using the `isArtsdataUri` helper and translation keys. [[1]](diffhunk://#diff-bf03dfb2a1d08bc13788fc4c8a0dfafe0f2347590b06a2e19dba95ed43a2e7ebR72-R75) [[2]](diffhunk://#diff-bf03dfb2a1d08bc13788fc4c8a0dfafe0f2347590b06a2e19dba95ed43a2e7ebL103-R108)