### PR TITLE
Fix padding, taxonomy reconciliation, and redirection issues

### DIFF
--- a/src/components/List/SelectionItem/SelectionItem.jsx
+++ b/src/components/List/SelectionItem/SelectionItem.jsx
@@ -17,6 +17,7 @@ import { PathName } from '../../../constants/pathName.js';
 import { useNavigate, useParams } from 'react-router-dom';
 import Link from 'antd/lib/typography/Link.js';
 import { truncateText } from '../../../utils/stringManipulations.js';
+import { isArtsdataUri } from '../../../utils/artsDataLinkChecker.js';
 function SelectionItem(props) {
   const {
     icon,
@@ -68,6 +69,10 @@ function SelectionItem(props) {
     ? t('common.forms.languageLiterals.unKnownLanguagePromptText')
     : t('common.forms.languageLiterals.knownLanguagePromptText');
 
+  const externalSourceLinkLabel = isArtsdataUri(artsDataLink)
+    ? t('dashboard.events.createNew.search.linkText')
+    : t('dashboard.events.createNew.search.datafeed');
+
   const routinghandler = (e) => {
     const type = onClickHandle?.entityType;
     const id = onClickHandle?.entityId;
@@ -100,7 +105,7 @@ function SelectionItem(props) {
             <ArtsDataLink data-cy="artsdata-link-tag">
               <Link href={artsDataLink} target="_blank" rel="noopener noreferrer" onClick={(e) => e.stopPropagation()}>
                 <div style={{ display: 'flex', gap: '7px', color: '#0f0e98' }}>
-                  <span style={{ textDecoration: 'underline' }}>Artsdata</span>
+                  <span style={{ textDecoration: 'underline' }}>{externalSourceLinkLabel}</span>
                   <LinkOutlined style={{ display: 'grid', placeContent: 'center', color: '#0f0e98' }} />
                 </div>
               </Link>

--- a/src/components/List/SelectionItem/SelectionItem.jsx
+++ b/src/components/List/SelectionItem/SelectionItem.jsx
@@ -69,7 +69,7 @@ function SelectionItem(props) {
     ? t('common.forms.languageLiterals.unKnownLanguagePromptText')
     : t('common.forms.languageLiterals.knownLanguagePromptText');
 
-  const externalSourceLinkLabel = isArtsdataUri(artsDataLink)
+  const externalSourceLinkLabel = artsDataLink && isArtsdataUri(artsDataLink)
     ? t('dashboard.events.createNew.search.linkText')
     : t('dashboard.events.createNew.search.datafeed');
 

--- a/src/components/List/SelectionItem/SelectionItem.jsx
+++ b/src/components/List/SelectionItem/SelectionItem.jsx
@@ -69,9 +69,10 @@ function SelectionItem(props) {
     ? t('common.forms.languageLiterals.unKnownLanguagePromptText')
     : t('common.forms.languageLiterals.knownLanguagePromptText');
 
-  const externalSourceLinkLabel = artsDataLink && isArtsdataUri(artsDataLink)
-    ? t('dashboard.events.createNew.search.linkText')
-    : t('dashboard.events.createNew.search.datafeed');
+  const externalSourceLinkLabel =
+    artsDataLink && isArtsdataUri(artsDataLink)
+      ? t('dashboard.events.createNew.search.linkText')
+      : t('dashboard.events.createNew.search.datafeed');
 
   const routinghandler = (e) => {
     const type = onClickHandle?.entityType;

--- a/src/components/Select/selectOption.settings.js
+++ b/src/components/Select/selectOption.settings.js
@@ -5,6 +5,7 @@ import { languageFallbackStatusCreator } from '../../utils/languageFallbackStatu
 import { isDataValid } from '../../utils/MultiLingualFormItemSupportFunctions';
 import SelectionItem from '../List/SelectionItem';
 import { EnvironmentOutlined } from '@ant-design/icons';
+import { createArtsDataLink } from '../../utils/artsDataLinkChecker';
 
 export const taxonomyOptions = (data, user, mappedToField, calendarContentLanguage) => {
   let fieldData = data?.data?.filter((taxonomy) => taxonomy?.mappedToField === mappedToField);
@@ -70,7 +71,7 @@ export const placesOptions = (
               : typeof place?.description === 'string' && place?.description
           }
           calendarContentLanguage={calendarContentLanguage}
-          artsDataLink={place?.uri}
+          artsDataLink={createArtsDataLink(place?.uri)}
           showExternalSourceLink={true}
         />
       ),

--- a/src/components/TreeSelectOption/treeSelectOption.settings.js
+++ b/src/components/TreeSelectOption/treeSelectOption.settings.js
@@ -7,6 +7,7 @@ import { sourceOptions } from '../../constants/sourceOptions';
 import { languageFallbackStatusCreator } from '../../utils/languageFallbackStatusCreator';
 import { contentLanguageKeyMap } from '../../constants/contentLanguage';
 import { isDataValid } from '../../utils/MultiLingualFormItemSupportFunctions';
+import { createArtsDataLink } from '../../utils/artsDataLinkChecker';
 
 const handleMultilevelTreeSelect = (children, user, calendarContentLanguage, parentLabel) => {
   return children?.map((child) => {
@@ -143,7 +144,7 @@ export const treeEntitiesOption = (
               : typeof entity?.description === 'string' && entity?.description
           }
           calendarContentLanguage={calendarContentLanguage}
-          artsDataLink={entity?.uri}
+          artsDataLink={createArtsDataLink(entity?.uri)}
           showExternalSourceLink={true}
         />
       ),

--- a/src/layout/CreateNewEntity/NewEntityLayout.jsx
+++ b/src/layout/CreateNewEntity/NewEntityLayout.jsx
@@ -15,7 +15,7 @@ const NewEntityLayout = ({ children, heading, text, entityName, searchHeading })
   return (
     <FeatureFlag isFeatureEnabled={featureFlags.editScreenPeoplePlaceOrganization}>
       <Row className="create-new-entity-page" gutter={[0, 24]}>
-        <Col span={24}>
+        <Col span={24} className="create-new-entity-sticky-header">
           <div className="button-container">
             <Button type="link" onClick={() => navigate(-1)} data-cy="button-breadcrumb-back-to-previous-page">
               <LeftOutlined style={{ fontSize: '12px', paddingRight: '5px' }} />

--- a/src/layout/CreateNewEntity/createNew.css
+++ b/src/layout/CreateNewEntity/createNew.css
@@ -1,3 +1,16 @@
+.create-new-entity-page .create-new-entity-sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #f9faff;
+  margin-left: -32px;
+  margin-right: -32px;
+  padding-left: 32px;
+  padding-right: 32px;
+  padding-top: 32px;
+  padding-bottom: 8px;
+}
+
 .create-new-entity-page .button-container .ant-btn {
   color: #0f0e98;
   border: none;
@@ -43,6 +56,14 @@
 }
 
 @media (max-width: 768px) {
+  .create-new-entity-page .create-new-entity-sticky-header {
+    margin-left: -16px;
+    margin-right: -16px;
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 32px;
+  }
+
   .create-new-entity-page .content .text {
     font-weight: 700;
   }

--- a/src/pages/Dashboard/Events/Events.jsx
+++ b/src/pages/Dashboard/Events/Events.jsx
@@ -68,6 +68,7 @@ import {
   IMPORT_ACTION_KEY,
   REPORT_ACTION_KEY,
 } from '../../../constants/entitiesClass';
+import { reconcileTaxonomyFilters } from '../../../utils/taxonomyFilterReconciliation';
 
 const { useBreakpoint } = Grid;
 const standardTaxonomyMaps = [
@@ -291,7 +292,32 @@ function Events() {
   );
 
   const calendar = getCurrentCalendarDetailsFromUserDetails(user, calendarId);
-  let customFilters = [...(currentCalendarData?.filterPersonalization?.events ?? [])];
+  let customFilters = currentCalendarData?.filterPersonalization?.events ?? [];
+
+  useEffect(() => {
+    if (!allTaxonomyData?.data?.length) return;
+
+    const {
+      reconciledTaxonomyFilter,
+      reconciledStandardTaxonomyFilter,
+      isTaxonomyFilterChanged,
+      isStandardTaxonomyFilterChanged,
+    } = reconcileTaxonomyFilters({
+      taxonomyFilter,
+      standardTaxonomyFilter,
+      taxonomies: allTaxonomyData?.data,
+      customFilters,
+    });
+
+    if (isTaxonomyFilterChanged) {
+      setTaxonomyFilter(reconciledTaxonomyFilter);
+    }
+
+    if (isStandardTaxonomyFilterChanged) {
+      setStandardTaxonomyFilter(reconciledStandardTaxonomyFilter);
+    }
+  }, [allTaxonomyData?.data, customFilters, taxonomyFilter, standardTaxonomyFilter]);
+
   const dateTypeSelector = (dates) => {
     if (dates?.length == 2) {
       if (dates?.every((date) => date === 'any')) return dateFilterTypes.ALL_EVENTS;

--- a/src/pages/Dashboard/Organizations/Organizations.jsx
+++ b/src/pages/Dashboard/Organizations/Organizations.jsx
@@ -47,6 +47,7 @@ import SearchableCheckbox from '../../../components/Filter/SearchableCheckbox';
 import { entitiesClass } from '../../../constants/entitiesClass';
 import EntityReports from '../../../components/EntityReports/EntityReports';
 import ReadOnlyProtectedComponent from '../../../layout/ReadOnlyProtectedComponent';
+import { reconcileTaxonomyFilters } from '../../../utils/taxonomyFilterReconciliation';
 
 const { useBreakpoint } = Grid;
 
@@ -147,6 +148,30 @@ function Organizations() {
 
   let customFilters = currentCalendarData?.filterPersonalization?.organization ?? [];
 
+  useEffect(() => {
+    if (!allTaxonomyData?.data?.length) return;
+
+    const {
+      reconciledTaxonomyFilter,
+      reconciledStandardTaxonomyFilter,
+      isTaxonomyFilterChanged,
+      isStandardTaxonomyFilterChanged,
+    } = reconcileTaxonomyFilters({
+      taxonomyFilter,
+      standardTaxonomyFilter,
+      taxonomies: allTaxonomyData?.data,
+      customFilters,
+    });
+
+    if (isTaxonomyFilterChanged) {
+      setTaxonomyFilter(reconciledTaxonomyFilter);
+    }
+
+    if (isStandardTaxonomyFilterChanged) {
+      setStandardTaxonomyFilter(reconciledStandardTaxonomyFilter);
+    }
+  }, [allTaxonomyData?.data, customFilters, taxonomyFilter, standardTaxonomyFilter]);
+
   const deleteOrganizationHandler = (organizationId) => {
     getDependencyDetails({ ids: organizationId, calendarId })
       .unwrap()
@@ -222,6 +247,7 @@ function Organizations() {
       order: sortOrder?.ASC,
     });
     setTaxonomyFilter({});
+    setStandardTaxonomyFilter({});
     setUserFilter([]);
     setOrganizationIdFilter([]);
     setPageNumber(1);
@@ -661,6 +687,7 @@ function Organizations() {
               <Col>
                 {(filter?.order === sortOrder?.DESC ||
                   Object.keys(taxonomyFilter)?.length > 0 ||
+                  Object.keys(standardTaxonomyFilter)?.length > 0 ||
                   userFilter.length > 0 ||
                   organizationIdFilter.length > 0 ||
                   filter?.sort != sortByOptionsOrgsPlacesPerson[0]?.key) && (

--- a/src/pages/Dashboard/People/People.jsx
+++ b/src/pages/Dashboard/People/People.jsx
@@ -46,6 +46,7 @@ import { removeObjectArrayDuplicates } from '../../../utils/removeObjectArrayDup
 import { entitiesClass } from '../../../constants/entitiesClass';
 import EntityReports from '../../../components/EntityReports/EntityReports';
 import ReadOnlyProtectedComponent from '../../../layout/ReadOnlyProtectedComponent';
+import { reconcileTaxonomyFilters } from '../../../utils/taxonomyFilterReconciliation';
 
 const { useBreakpoint } = Grid;
 const standardTaxonomyMaps = [
@@ -149,6 +150,30 @@ function People() {
   const calendar = getCurrentCalendarDetailsFromUserDetails(user, calendarId);
 
   let customFilters = currentCalendarData?.filterPersonalization?.people ?? [];
+
+  useEffect(() => {
+    if (!allTaxonomyData?.data?.length) return;
+
+    const {
+      reconciledTaxonomyFilter,
+      reconciledStandardTaxonomyFilter,
+      isTaxonomyFilterChanged,
+      isStandardTaxonomyFilterChanged,
+    } = reconcileTaxonomyFilters({
+      taxonomyFilter,
+      standardTaxonomyFilter,
+      taxonomies: allTaxonomyData?.data,
+      customFilters,
+    });
+
+    if (isTaxonomyFilterChanged) {
+      setTaxonomyFilter(reconciledTaxonomyFilter);
+    }
+
+    if (isStandardTaxonomyFilterChanged) {
+      setStandardTaxonomyFilter(reconciledStandardTaxonomyFilter);
+    }
+  }, [allTaxonomyData?.data, customFilters, taxonomyFilter, standardTaxonomyFilter]);
 
   const deletePersonHandler = (personId) => {
     getDependencyDetails({ ids: personId, calendarId })

--- a/src/pages/Dashboard/Places/Places.jsx
+++ b/src/pages/Dashboard/Places/Places.jsx
@@ -46,6 +46,7 @@ import { SEARCH_DELAY } from '../../../constants/search';
 import { entitiesClass } from '../../../constants/entitiesClass';
 import EntityReports from '../../../components/EntityReports/EntityReports';
 import ReadOnlyProtectedComponent from '../../../layout/ReadOnlyProtectedComponent';
+import { reconcileTaxonomyFilters } from '../../../utils/taxonomyFilterReconciliation';
 
 const { useBreakpoint } = Grid;
 const standardTaxonomyMaps = [
@@ -164,6 +165,30 @@ function Places() {
 
   let customFilters = currentCalendarData?.filterPersonalization?.places ?? [];
 
+  useEffect(() => {
+    if (!allTaxonomyData?.data?.length) return;
+
+    const {
+      reconciledTaxonomyFilter,
+      reconciledStandardTaxonomyFilter,
+      isTaxonomyFilterChanged,
+      isStandardTaxonomyFilterChanged,
+    } = reconcileTaxonomyFilters({
+      taxonomyFilter,
+      standardTaxonomyFilter,
+      taxonomies: allTaxonomyData?.data,
+      customFilters,
+    });
+
+    if (isTaxonomyFilterChanged) {
+      setTaxonomyFilter(reconciledTaxonomyFilter);
+    }
+
+    if (isStandardTaxonomyFilterChanged) {
+      setStandardTaxonomyFilter(reconciledStandardTaxonomyFilter);
+    }
+  }, [allTaxonomyData?.data, customFilters, taxonomyFilter, standardTaxonomyFilter]);
+
   const deletePlaceHandler = (placeId) => {
     getDependencyDetails({ ids: placeId, calendarId })
       .unwrap()
@@ -252,8 +277,8 @@ function Places() {
     sessionStorage.removeItem('placesPage');
     sessionStorage.removeItem('placesSearchQuery');
     sessionStorage.removeItem('placeOrder');
-    sessionStorage.removeItem('taxonomyFilter');
-    sessionStorage.removeItem('standardTaxonomyFilter');
+    sessionStorage.removeItem('placeTaxonomyFilter');
+    sessionStorage.removeItem('standardPlaceTaxonomyFilter');
     sessionStorage.removeItem('placeSortBy');
   };
 

--- a/src/pages/Dashboard/SearchOrganizations/SearchOrganizations.jsx
+++ b/src/pages/Dashboard/SearchOrganizations/SearchOrganizations.jsx
@@ -12,7 +12,7 @@ import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { getUserDetails } from '../../../redux/reducer/userSlice';
 import { contentLanguageBilingual } from '../../../utils/bilingual';
-import { artsDataLinkChecker, createArtsDataLink, isArtsdataUri } from '../../../utils/artsDataLinkChecker';
+import { createArtsDataLink, isArtsdataUri } from '../../../utils/artsDataLinkChecker';
 import CreateEntityButton from '../../../components/Card/Common/CreateEntityButton';
 import { PathName } from '../../../constants/pathName';
 import { Popover } from 'antd';
@@ -304,7 +304,7 @@ function SearchOrganizations() {
                                 calendarContentLanguage: calendarContentLanguage,
                               })}
                               isTransparent={organizer?.logo?.isTransparent ?? false}
-                              artsDataLink={artsDataLinkChecker(organizer?.uri)}
+                              artsDataLink={createArtsDataLink(organizer?.uri)}
                               Logo={
                                 organizer.logo ? (
                                   <img src={organizer.logo?.thumbnail?.uri} data-cy={`img-entity-logo-${index}`} />
@@ -374,7 +374,7 @@ function SearchOrganizations() {
                                 calendarContentLanguage: calendarContentLanguage,
                               })}
                               description={organizer?.description}
-                              artsDataLink={organizer?.uri}
+                              artsDataLink={createArtsDataLink(organizer?.uri)}
                               Logo={organizer.logo ? <img src={organizer?.logo?.thumbnail?.uri} /> : <Logo />}
                               linkText={
                                 isArtsdataUri(organizer?.uri)

--- a/src/pages/Dashboard/SearchPerson/SearchPerson.jsx
+++ b/src/pages/Dashboard/SearchPerson/SearchPerson.jsx
@@ -12,7 +12,7 @@ import { PathName } from '../../../constants/pathName';
 import NewEntityLayout from '../../../layout/CreateNewEntity/NewEntityLayout';
 import { getUserDetails } from '../../../redux/reducer/userSlice';
 import { useGetEntitiesQuery, useLazyGetEntitiesQuery } from '../../../services/entities';
-import { artsDataLinkChecker, createArtsDataLink, isArtsdataUri } from '../../../utils/artsDataLinkChecker';
+import { createArtsDataLink, isArtsdataUri } from '../../../utils/artsDataLinkChecker';
 import { UserOutlined } from '@ant-design/icons';
 import { contentLanguageBilingual } from '../../../utils/bilingual';
 import './searchPerson.css';
@@ -232,7 +232,7 @@ function SearchPerson() {
                             interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
                             calendarContentLanguage: calendarContentLanguage,
                           })}
-                          artsDataLink={artsDataLinkChecker(person?.uri)}
+                          artsDataLink={createArtsDataLink(person?.uri)}
                           Logo={
                             person.logo ? (
                               person.logo?.thumbnail?.uri
@@ -303,7 +303,7 @@ function SearchPerson() {
                                 interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
                                 calendarContentLanguage: calendarContentLanguage,
                               })}
-                              artsDataLink={artsDataLinkChecker(person?.uri)}
+                              artsDataLink={createArtsDataLink(person?.uri)}
                               Logo={
                                 person.logo ? (
                                   person.logo?.thumbnail?.uri

--- a/src/pages/Dashboard/SearchPlaces/SearchPlaces.jsx
+++ b/src/pages/Dashboard/SearchPlaces/SearchPlaces.jsx
@@ -10,7 +10,7 @@ import EventsSearch from '../../../components/Search/Events/EventsSearch';
 import { PathName } from '../../../constants/pathName';
 import NewEntityLayout from '../../../layout/CreateNewEntity/NewEntityLayout';
 import { getUserDetails } from '../../../redux/reducer/userSlice';
-import { artsDataLinkChecker, createArtsDataLink, isArtsdataUri } from '../../../utils/artsDataLinkChecker';
+import { createArtsDataLink, isArtsdataUri } from '../../../utils/artsDataLinkChecker';
 import { contentLanguageBilingual } from '../../../utils/bilingual';
 import { EnvironmentOutlined } from '@ant-design/icons';
 import './searchPlaces.css';
@@ -232,7 +232,7 @@ function SearchPlaces() {
                             interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
                             calendarContentLanguage: calendarContentLanguage,
                           })}
-                          artsDataLink={artsDataLinkChecker(place?.uri)}
+                          artsDataLink={createArtsDataLink(place?.uri)}
                           Logo={
                             place.logo ? (
                               place.logo?.thumbnail?.uri
@@ -303,7 +303,7 @@ function SearchPlaces() {
                                 interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
                                 calendarContentLanguage: calendarContentLanguage,
                               })}
-                              artsDataLink={artsDataLinkChecker(place?.uri)}
+                              artsDataLink={createArtsDataLink(place?.uri)}
                               Logo={
                                 place.logo ? (
                                   place.logo?.thumbnail?.uri

--- a/src/pages/Dashboard/SelectTaxonomyType/SelectTaxonomyType.jsx
+++ b/src/pages/Dashboard/SelectTaxonomyType/SelectTaxonomyType.jsx
@@ -77,7 +77,7 @@ const SelectTaxonomyType = () => {
 
   return (
     <div className="select-taxonomy-type-wrapper">
-      <Row>
+      <Row className="select-taxonomy-type-sticky-header">
         <Col span={24}>
           <div className="button-container">
             <Button type="link" onClick={() => navigate(-1)} data-cy="button-taxonomy-back-to-previous">

--- a/src/pages/Dashboard/SelectTaxonomyType/selectTaxonomyType.css
+++ b/src/pages/Dashboard/SelectTaxonomyType/selectTaxonomyType.css
@@ -1,3 +1,16 @@
+.select-taxonomy-type-wrapper .select-taxonomy-type-sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #f9faff;
+  margin-left: -32px;
+  margin-right: -32px;
+  padding-left: 32px;
+  padding-right: 32px;
+  padding-top: 32px;
+  padding-bottom: 8px;
+}
+
 .select-taxonomy-type-wrapper .button-container .ant-btn {
   color: #0f0e98;
   border: none;
@@ -12,7 +25,6 @@
 .select-taxonomy-type-wrapper .heading {
   font-size: 34px;
   font-weight: 700;
-  padding-top: 16px;
 }
 
 .select-taxonomy-type-wrapper .ant-form-item-label > label {
@@ -76,5 +88,15 @@
   .select-taxonomy-type-wrapper .info-message,
   .select-taxonomy-type-wrapper .ant-form-item-explain-error {
     font-size: 12px;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .select-taxonomy-type-wrapper .select-taxonomy-type-sticky-header {
+    margin-left: -16px;
+    margin-right: -16px;
+    padding-left: 16px;
+    padding-right: 16px;
+    padding-top: 32px;
   }
 }

--- a/src/utils/taxonomyFilterReconciliation.js
+++ b/src/utils/taxonomyFilterReconciliation.js
@@ -1,0 +1,109 @@
+const normalizeConceptIds = (concepts = []) => {
+  if (!Array.isArray(concepts)) return [];
+
+  const uniqueConceptIds = [];
+  const seen = new Set();
+
+  concepts.forEach((concept) => {
+    const conceptId = concept?.id ?? concept;
+    if (conceptId === null || conceptId === undefined) return;
+
+    const normalizedConceptId = String(conceptId);
+    if (seen.has(normalizedConceptId)) return;
+
+    seen.add(normalizedConceptId);
+    uniqueConceptIds.push(normalizedConceptId);
+  });
+
+  return uniqueConceptIds;
+};
+
+const buildAllowedTaxonomySelections = ({ taxonomies = [], customFilters = [] }) => {
+  const customFilterIds = new Set((customFilters ?? []).map((id) => String(id)));
+
+  const dynamicTaxonomyConcepts = new Map();
+  const standardTaxonomyConcepts = new Map();
+
+  (taxonomies ?? []).forEach((taxonomy) => {
+    if (!taxonomy?.id || !customFilterIds.has(String(taxonomy.id))) return;
+
+    const conceptIds = normalizeConceptIds(taxonomy?.concept);
+
+    if (taxonomy?.isDynamicField) {
+      dynamicTaxonomyConcepts.set(String(taxonomy.id), new Set(conceptIds));
+      return;
+    }
+
+    if (taxonomy?.mappedToField) {
+      standardTaxonomyConcepts.set(String(taxonomy.mappedToField), new Set(conceptIds));
+    }
+  });
+
+  return {
+    dynamicTaxonomyConcepts,
+    standardTaxonomyConcepts,
+  };
+};
+
+const reconcileFilterByAllowedConcepts = (selectedFilter = {}, allowedTaxonomyConceptMap = new Map()) => {
+  const reconciledFilter = {};
+  let changed = false;
+
+  Object.entries(selectedFilter ?? {}).forEach(([taxonomyKey, selectedConceptIds]) => {
+    const normalizedTaxonomyKey = String(taxonomyKey);
+    const allowedConceptIds = allowedTaxonomyConceptMap.get(normalizedTaxonomyKey);
+
+    if (!allowedConceptIds) {
+      changed = true;
+      return;
+    }
+
+    const normalizedSelectedConceptIds = normalizeConceptIds(selectedConceptIds);
+    const validConceptIds = normalizedSelectedConceptIds.filter((conceptId) => allowedConceptIds.has(conceptId));
+
+    if (validConceptIds.length === 0) {
+      changed = true;
+      return;
+    }
+
+    if (validConceptIds.length !== normalizedSelectedConceptIds.length) {
+      changed = true;
+    }
+
+    reconciledFilter[normalizedTaxonomyKey] = validConceptIds;
+  });
+
+  if (Object.keys(reconciledFilter).length !== Object.keys(selectedFilter ?? {}).length) {
+    changed = true;
+  }
+
+  return {
+    reconciledFilter,
+    changed,
+  };
+};
+
+export const reconcileTaxonomyFilters = ({
+  taxonomyFilter = {},
+  standardTaxonomyFilter = {},
+  taxonomies = [],
+  customFilters = [],
+}) => {
+  const { dynamicTaxonomyConcepts, standardTaxonomyConcepts } = buildAllowedTaxonomySelections({
+    taxonomies,
+    customFilters,
+  });
+
+  const { reconciledFilter: reconciledTaxonomyFilter, changed: isTaxonomyFilterChanged } =
+    reconcileFilterByAllowedConcepts(taxonomyFilter, dynamicTaxonomyConcepts);
+
+  const { reconciledFilter: reconciledStandardTaxonomyFilter, changed: isStandardTaxonomyFilterChanged } =
+    reconcileFilterByAllowedConcepts(standardTaxonomyFilter, standardTaxonomyConcepts);
+
+  return {
+    reconciledTaxonomyFilter,
+    reconciledStandardTaxonomyFilter,
+    isTaxonomyFilterChanged,
+    isStandardTaxonomyFilterChanged,
+  };
+};


### PR DESCRIPTION
This pull request introduces several improvements across the codebase, focusing on taxonomy filter reconciliation for entity dashboards, standardizing the creation and display of Artsdata links, and enhancing the UI for entity creation pages. The main themes are improved filter consistency, better UX for external links, and a sticky header for the entity creation layout.

**Taxonomy filter reconciliation and consistency:**

* Added a `useEffect` in `Events`, `Organizations`, `People`, and `Places` dashboard pages to automatically reconcile and update taxonomy filters using the new `reconcileTaxonomyFilters` utility, ensuring filters remain consistent with the latest taxonomy data and user personalization. [[1]](diffhunk://#diff-53e1775d15b31ee41a29af44278114f697491f4f47c6cfdca84805257329bd55L294-R320) [[2]](diffhunk://#diff-eb021b9450dc17f8965a2713103daff02ae66b0f805061a68b124fdf0727f16fR151-R174) [[3]](diffhunk://#diff-036bec836d907bbf62f5e0ce53ea5b9570b545192b56585b4b553a45a0c21be4R154-R177) [[4]](diffhunk://#diff-0320145f9c75fa4863b19f95cf75b9cfae71e153b709613678bf9aac490a3852R168-R191)
* Reset both `taxonomyFilter` and `standardTaxonomyFilter` when clearing filters in organizations and places dashboards, and updated session storage keys for place filters to avoid collisions. [[1]](diffhunk://#diff-eb021b9450dc17f8965a2713103daff02ae66b0f805061a68b124fdf0727f16fR250) [[2]](diffhunk://#diff-0320145f9c75fa4863b19f95cf75b9cfae71e153b709613678bf9aac490a3852L255-R281)
* Updated filter UI to reflect the presence of both taxonomy and standard taxonomy filters.

**Artsdata link handling and display:**

* Standardized the creation of Artsdata links by consistently using the `createArtsDataLink` utility instead of directly passing URIs or using the old `artsDataLinkChecker`, across selection, tree select, and search components for organizations, people, and places. [[1]](diffhunk://#diff-0a98c34f99d04a377fcee837f05628304969462e062f67a48d7903d7cb2aa370L73-R74) [[2]](diffhunk://#diff-7287b51d4b35aae0f1f246c37417e75bd09257f5bf1fd499396cdb47416d7a82L146-R147) [[3]](diffhunk://#diff-e07e6e59c0d52945d209be76a876a752ffbacc61e195fc0c2835b34ac4c28efdL307-R307) [[4]](diffhunk://#diff-e07e6e59c0d52945d209be76a876a752ffbacc61e195fc0c2835b34ac4c28efdL377-R377) [[5]](diffhunk://#diff-e699ccf174ac04791d97d89ce6524ece437a5dab9a13e7154c236106d3141895L235-R235) [[6]](diffhunk://#diff-e699ccf174ac04791d97d89ce6524ece437a5dab9a13e7154c236106d3141895L306-R306)
* Improved the label for external Artsdata links in `SelectionItem` to dynamically display either a generic datafeed label or a specific "Artsdata" label, based on the link type. [[1]](diffhunk://#diff-bf03dfb2a1d08bc13788fc4c8a0dfafe0f2347590b06a2e19dba95ed43a2e7ebR72-R75) [[2]](diffhunk://#diff-bf03dfb2a1d08bc13788fc4c8a0dfafe0f2347590b06a2e19dba95ed43a2e7ebL103-R108)

**UI/UX enhancements:**

* Made the header in the `CreateNewEntity` layout sticky for better navigation, with responsive CSS adjustments for different screen sizes. [[1]](diffhunk://#diff-870d7303f87f6384329fbd42d5929de3da2ad8ea5d6e4ba0b5bb6243b33c6242L18-R18) [[2]](diffhunk://#diff-2daa83ce667c98c991de987a3edc2f9bea30618c0b257b84f64744d6bc3ab858R1-R13) [[3]](diffhunk://#diff-2daa83ce667c98c991de987a3edc2f9bea30618c0b257b84f64744d6bc3ab858R59-R66)

**Code cleanup and consistency:**

* Removed unused imports and ensured only the necessary utilities are imported for Artsdata link handling. [[1]](diffhunk://#diff-e07e6e59c0d52945d209be76a876a752ffbacc61e195fc0c2835b34ac4c28efdL15-R15) [[2]](diffhunk://#diff-e699ccf174ac04791d97d89ce6524ece437a5dab9a13e7154c236106d3141895L15-R15) [[3]](diffhunk://#diff-fcf235711126846b08263b6efecbcaf793d859e89f47aa1380c1e46b40d26f80L13-R13) [[4]](diffhunk://#diff-bf03dfb2a1d08bc13788fc4c8a0dfafe0f2347590b06a2e19dba95ed43a2e7ebR20)
* Updated all relevant selection and search components to use the new link handling logic for consistency. [[1]](diffhunk://#diff-0a98c34f99d04a377fcee837f05628304969462e062f67a48d7903d7cb2aa370R8) [[2]](diffhunk://#diff-7287b51d4b35aae0f1f246c37417e75bd09257f5bf1fd499396cdb47416d7a82R10)

These changes collectively improve the maintainability, user experience, and reliability of taxonomy filtering and external link handling throughout the dashboard.