### PR TITLE
Separate added fields into distinct states

### DIFF
--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -211,7 +211,10 @@ function AddEvent() {
     performer: false,
     supporter: false,
   });
-  const [addedFields, setAddedFields] = useState([]);
+  const [requiredAddedFields, setRequiredAddedFields] = useState([]);
+  const [eventSeedAddedFields, setEventSeedAddedFields] = useState([]);
+  const [artsDataSeedAddedFields, setArtsDataSeedAddedFields] = useState([]);
+  const [userAddedFields, setUserAddedFields] = useState([]);
   const [showDialog, setShowDialog] = useState(false);
   const [scrollToSelectedField, setScrollToSelectedField] = useState();
   const [formValue, setFormValue] = useState();
@@ -229,6 +232,19 @@ function AddEvent() {
   const [artsDataLoading, setArtsDataLoading] = useState(false);
   const [debouncedLoading, setDebouncedLoading] = useState(true);
   const [dynamicFields, setDynamicFields] = useState([]);
+
+  const mergeUniqueFields = (...fieldGroups) => [
+    ...new Set(
+      fieldGroups
+        .flatMap((fields) => fields ?? [])
+        .filter((field) => field !== undefined && field !== null && field !== ''),
+    ),
+  ];
+
+  const addedFields = useMemo(
+    () => mergeUniqueFields(requiredAddedFields, eventSeedAddedFields, artsDataSeedAddedFields, userAddedFields),
+    [requiredAddedFields, eventSeedAddedFields, artsDataSeedAddedFields, userAddedFields],
+  );
 
   const isAnyLoading = useMemo(
     () =>
@@ -1791,10 +1807,9 @@ function AddEvent() {
   );
 
   const addFieldsHandler = (fieldNames) => {
-    let array = addedFields?.concat(fieldNames);
-    array = [...new Set(array)];
-    setAddedFields(array);
-    setScrollToSelectedField(array?.at(-1));
+    const fieldsToAdd = Array.isArray(fieldNames) ? fieldNames : [fieldNames];
+    setUserAddedFields((prev) => mergeUniqueFields(prev, fieldsToAdd));
+    setScrollToSelectedField(fieldsToAdd?.at(-1));
   };
 
   const handleDateTypeChange = (activeDateType) => {
@@ -2139,7 +2154,7 @@ function AddEvent() {
   };
 
   const getArtsDataEvent = () => {
-    let initialAddedFields = [...addedFields];
+    let initialAddedFields = [];
     let importFailures = {
       location: { failed: false, count: 0, total: 0 },
       organizers: { failed: false, count: 0, total: 0 },
@@ -2493,7 +2508,7 @@ function AddEvent() {
           }
 
           setArtsData(data);
-          setAddedFields(initialAddedFields);
+          setArtsDataSeedAddedFields(initialAddedFields);
           setFailedImports(importFailures);
           setArtsDataLoading(false);
         }
@@ -2607,7 +2622,7 @@ function AddEvent() {
 
   useEffect(() => {
     if (calendarId && eventData && currentCalendarData) {
-      let initialAddedFields = [...addedFields],
+      let initialAddedFields = [],
         isRecurring = false;
 
       if (routinghandler(user, calendarId, eventData?.creator?.userId, eventData?.publishState, false) || duplicateId) {
@@ -2782,7 +2797,7 @@ function AddEvent() {
           initialAddedFields = initialAddedFields?.concat(eventAccessibilityFieldNames?.noteWrap);
         if (eventData?.inLanguage?.length > 0)
           initialAddedFields = initialAddedFields?.concat(otherInformationFieldNames?.inLanguage);
-        setAddedFields(initialAddedFields);
+        setEventSeedAddedFields(initialAddedFields);
         if (eventData?.recurringEvent && eventData?.recurringEvent?.frequency != 'CUSTOM') {
           form.setFieldsValue({
             frequency: eventData?.recurringEvent?.frequency,
@@ -3063,9 +3078,21 @@ function AddEvent() {
       });
       publishValidateFields = [...new Set(publishValidateFields)];
       setValidateFields(publishValidateFields);
-      setAddedFields(initialAddedFields);
+      setRequiredAddedFields(initialAddedFields);
     }
   }, [currentCalendarData]);
+
+  useEffect(() => {
+    if (!eventId && !duplicateId) {
+      setEventSeedAddedFields([]);
+    }
+  }, [eventId, duplicateId]);
+
+  useEffect(() => {
+    if (!artsDataId) {
+      setArtsDataSeedAddedFields([]);
+    }
+  }, [artsDataId]);
 
   useEffect(() => {
     if (isReadOnly) {
@@ -3082,7 +3109,7 @@ function AddEvent() {
           ?.concept?.map((concept) => (concept?.isDefault === true ? concept?.id : null))
           ?.filter((id) => id)?.length > 0
       )
-        setAddedFields(addedFields.concat(otherInformationFieldNames?.inLanguage));
+        setUserAddedFields((prev) => mergeUniqueFields(prev, [otherInformationFieldNames?.inLanguage]));
     }
   }, [taxonomyLoading]);
 


### PR DESCRIPTION
This pull request refactors how dynamically added fields are managed in the `AddEvent` component. Instead of using a single `addedFields` state, the code now tracks added fields in separate state variables based on their source (required, event seed, arts data seed, user-added). These are then merged into a unified list where necessary. This change improves clarity, maintainability, and enables more granular control over field management.

Key changes:

**State Management Refactor:**

* Replaced the single `addedFields` state with four specific states: `requiredAddedFields`, `eventSeedAddedFields`, `artsDataSeedAddedFields`, and `userAddedFields`, each tracking fields from different sources. The unified list of added fields is now computed using a `mergeUniqueFields` helper and exposed via a `useMemo` hook. [[1]](diffhunk://#diff-7c987cb6c339d6551d07d66dfd640b055e60e23f80f1c8a33b8034b8558b7233L214-R217) [[2]](diffhunk://#diff-7c987cb6c339d6551d07d66dfd640b055e60e23f80f1c8a33b8034b8558b7233R236-R248)

**Field Addition Logic:**

* Updated the `addFieldsHandler` and other field-adding logic to add fields specifically to `userAddedFields`, and to use the new merging strategy rather than directly mutating a single array. [[1]](diffhunk://#diff-7c987cb6c339d6551d07d66dfd640b055e60e23f80f1c8a33b8034b8558b7233L1794-R1812) [[2]](diffhunk://#diff-7c987cb6c339d6551d07d66dfd640b055e60e23f80f1c8a33b8034b8558b7233L3085-R3112)

**Field Initialization and Reset:**

* Modified logic in data import and initialization flows to set the appropriate field group state (`artsDataSeedAddedFields`, `eventSeedAddedFields`, `requiredAddedFields`) instead of the old `addedFields`. Also added effects to reset these groups when relevant identifiers change or are cleared. [[1]](diffhunk://#diff-7c987cb6c339d6551d07d66dfd640b055e60e23f80f1c8a33b8034b8558b7233L2142-R2157) [[2]](diffhunk://#diff-7c987cb6c339d6551d07d66dfd640b055e60e23f80f1c8a33b8034b8558b7233L2496-R2511) [[3]](diffhunk://#diff-7c987cb6c339d6551d07d66dfd640b055e60e23f80f1c8a33b8034b8558b7233L2610-R2625) [[4]](diffhunk://#diff-7c987cb6c339d6551d07d66dfd640b055e60e23f80f1c8a33b8034b8558b7233L2785-R2800) [[5]](diffhunk://#diff-7c987cb6c339d6551d07d66dfd640b055e60e23f80f1c8a33b8034b8558b7233L3066-R3096)

These changes collectively make the management of dynamic form fields more modular and easier to reason about.