### PR TITLE
Improve validation scroll and helper text spacing in forms

### DIFF
--- a/src/components/MultilingualInput/multilingualInput.css
+++ b/src/components/MultilingualInput/multilingualInput.css
@@ -69,6 +69,7 @@
 
 .bilingual-child-wrapper .ant-form-item {
   width: 100%;
+  margin-bottom: 0;
 }
 
 .bilingual-child-with-badge .ant-input-lg {

--- a/src/constants/formFields.js
+++ b/src/constants/formFields.js
@@ -696,7 +696,12 @@ export const renderFormFields = ({
         required={required}
         hidden={hidden}
         style={style}
-        className={mappedField ?? fieldName?.toLowerCase()}
+        className={[
+          mappedField ?? fieldName?.toLowerCase(),
+          position === 'bottom' && userTips ? 'form-item-with-bottom-helper' : undefined,
+        ]
+          .filter(Boolean)
+          .join(' ')}
         validateTrigger={datatype === dataTypes.URI_STRING ? ['onBlur'] : undefined}
         rules={rules
           ?.map((rule) => {
@@ -713,11 +718,10 @@ export const renderFormFields = ({
           ])
           ?.flat()
           ?.filter((rule) => rule !== undefined)}
-        help={
+        extra={
           position === 'bottom' && userTips ? (
             <p
               className="add-event-date-heading"
-              style={{ marginTop: '-15px' }}
               data-cy={`form-item-helper-text-${mappedField ?? fieldName?.toLowerCase()}`}>
               {userTips}
             </p>

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,18 @@ body {
   font-family: 'Roboto', sans-serif;
 }
 
+.form-item-with-bottom-helper .ant-form-item-explain-error {
+  margin-top: 2px;
+}
+
+.form-item-with-bottom-helper .ant-form-item-extra {
+  margin-top: 0;
+}
+
+.form-item-with-bottom-helper.ant-form-item-has-error .ant-form-item-extra {
+  margin-top: 8px;
+}
+
 .ant-input-status-error:not(.ant-input-disabled):not(.ant-input-borderless),
 .ant-input-status-error:not(.ant-input-disabled):not(.ant-input-borderless):hover {
   border-color: #ff4d4f !important;

--- a/src/pages/Dashboard/AddEvent/addEvent.css
+++ b/src/pages/Dashboard/AddEvent/addEvent.css
@@ -194,6 +194,10 @@
   width: 100% !important;
 }
 
+.event-form-wrapper .name .eventType {
+  margin-top: 24px;
+}
+
 .event-form-wrapper .responsive-view-control-class .aside-content-wrapper {
   padding: 0px;
 }

--- a/src/utils/scrollToFirstError.js
+++ b/src/utils/scrollToFirstError.js
@@ -12,6 +12,12 @@
 export const scrollToFirstError = (error, form, options = {}) => {
   if (!error?.errorFields?.length) return;
 
+  const firstField = error.errorFields[0]?.name;
+  if (firstField && typeof form?.scrollToField === 'function') {
+    form.scrollToField(firstField, { behavior: 'smooth', block: 'center' });
+    return;
+  }
+
   const { getElement } = options;
   let topmostEl = null;
   let topmostTop = Infinity;
@@ -31,8 +37,5 @@ export const scrollToFirstError = (error, form, options = {}) => {
 
   if (topmostEl) {
     topmostEl.scrollIntoView({ block: 'center', behavior: 'smooth' });
-  } else {
-    const firstField = error.errorFields[0]?.name;
-    if (firstField) form.scrollToField(firstField, { behavior: 'smooth', block: 'center' });
   }
 };

--- a/src/utils/scrollToFirstError.js
+++ b/src/utils/scrollToFirstError.js
@@ -13,11 +13,6 @@ export const scrollToFirstError = (error, form, options = {}) => {
   if (!error?.errorFields?.length) return;
 
   const firstField = error.errorFields[0]?.name;
-  if (firstField && typeof form?.scrollToField === 'function') {
-    form.scrollToField(firstField, { behavior: 'smooth', block: 'center' });
-    return;
-  }
-
   const { getElement } = options;
   let topmostEl = null;
   let topmostTop = Infinity;
@@ -37,5 +32,10 @@ export const scrollToFirstError = (error, form, options = {}) => {
 
   if (topmostEl) {
     topmostEl.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    return;
+  }
+
+  if (firstField && typeof form?.scrollToField === 'function') {
+    form.scrollToField(firstField, { behavior: 'smooth', block: 'center' });
   }
 };


### PR DESCRIPTION
This pull request introduces several improvements to form field rendering, error handling, and visual consistency in the UI. The main changes include enhanced styling for form item helper text, better error scrolling logic, and minor layout adjustments for event forms.

**Form rendering and helper text improvements:**

* Updated `renderFormFields` in `src/constants/formFields.js` to:
  - Dynamically add a `form-item-with-bottom-helper` class when a bottom-positioned user tip is present, improving targeted styling.
  - Switch from using the `help` prop to the `extra` prop for rendering user tips below form fields, ensuring correct Ant Design behavior and clearer separation from validation messages.

**Styling and layout adjustments:**

* Added new CSS rules in `src/index.css` to adjust spacing for fields with bottom helper text, especially in error states, for a more consistent and polished appearance.
* Set `margin-bottom: 0` for `.bilingual-child-wrapper .ant-form-item` in `multilingualInput.css` to tighten up form layouts.
* Introduced a top margin for `.eventType` fields in the event form for improved visual separation.

**Error scrolling logic:**

* Refactored `scrollToFirstError` in `src/utils/scrollToFirstError.js` to:
  - Store the first error field name earlier for clarity and reuse.
  - Only call `form.scrollToField` if a matching field is not found in the DOM, and ensure the function exists, preventing possible runtime errors.