### PR TITLE
feat: add search and pagination to calendar dropdown

### DIFF
--- a/.env.staging
+++ b/.env.staging
@@ -12,7 +12,7 @@ VITE_APP_FEATURE_FLAG_USERS=true
 VITE_APP_FEATURE_FLAG_TAXONOMY=true
 VITE_APP_FEATURE_FLAG_IMAGE_CROP=true
 VITE_APP_ENV="staging"
-VITE_APP_INVITE_URL="http://staging.cms.footlight.io/join?invitationId="
-VITE_APP_ACCEPT_URL="http://staging.cms.footlight.io/accept?invitationId="
+VITE_APP_INVITE_URL="http://staging-cms.footlight.io/join?invitationId="
+VITE_APP_ACCEPT_URL="http://staging-cms.footlight.io/accept?invitationId="
 VITE_APP_CALENDAR_WIDGET_BASE_URL="https://s3.ca-central-1.amazonaws.com/staging.cms-widget.footlight.io/v2/index.html"
 VITE_APP_FEATURE_FLAG_DOWNLOAD_ALL_DATA=true


### PR DESCRIPTION
- Replace Ant Design menu-based dropdown with custom dropdownRender
- Add search input with debounced server-side filtering
- Implement infinite scroll pagination (8 items per page)
- Update getAllCalendars query to accept page, limit, and search params
- Style search input, item list, loading indicator, and empty state