### PR TITLE
fix(calendar-dropdown): reset search paging to page 1 and stop auto-f…

### DIFF
--- a/src/components/Dropdown/Calendar/Calendar.jsx
+++ b/src/components/Dropdown/Calendar/Calendar.jsx
@@ -283,9 +283,9 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
     if (calendarIdInCookies !== key) {
       dispatch(setSelectedCalendar(String(key)));
       setRecentCalendarForUser({ user, calendarId: key });
-      sessionStorage.setItem('calendarId', key);
       setPageNumber(1);
       sessionStorage.clear();
+      sessionStorage.setItem('calendarId', key);
       setOpen(false);
       const origin = window.location.origin;
       const newUrl = `${origin}${PathName.Dashboard}/${key}${PathName.Events}`;

--- a/src/components/Dropdown/Calendar/Calendar.jsx
+++ b/src/components/Dropdown/Calendar/Calendar.jsx
@@ -58,6 +58,7 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
   const [open, setOpen] = useState(false);
   const [searchInput, setSearchInput] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
+  const [activeSearchTerm, setActiveSearchTerm] = useState('');
   const [calendars, setCalendars] = useState([]);
   const [totalCount, setTotalCount] = useState(0);
   const [currentPage, setCurrentPage] = useState(1);
@@ -192,6 +193,21 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
   );
 
   useEffect(() => {
+    if (!open) return;
+    if (activeSearchTerm === searchQuery) return;
+
+    inFlightPageKeysRef.current.clear();
+    loadedPageKeysRef.current.clear();
+    loadingMoreRef.current = false;
+    setCalendars([]);
+    setTotalCount(0);
+    setCurrentPage(1);
+    setActiveSearchTerm(searchQuery);
+
+    loadPage(1, searchQuery, false);
+  }, [activeSearchTerm, loadPage, open, searchQuery]);
+
+  useEffect(() => {
     return () => {
       if (activeRequestRef.current?.abort) {
         activeRequestRef.current.abort();
@@ -208,13 +224,6 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
   );
 
   useEffect(() => {
-    if (!open || !searchQuery || isFetching || !hasMore || loadingMoreRef.current) return;
-    if (!filteredCalendars.length) {
-      loadPage(currentPage + 1, searchQuery, true);
-    }
-  }, [open, searchQuery, isFetching, hasMore, filteredCalendars.length, loadPage, currentPage]);
-
-  useEffect(() => {
     const cachedData = cacheRef.current.get(cacheKey);
 
     if (open) {
@@ -222,10 +231,12 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
         setCalendars(cachedData.data);
         setTotalCount(cachedData.totalCount);
         setCurrentPage(cachedData.currentPage);
+        setActiveSearchTerm('');
       } else if (allCalendarsData?.data) {
         setCalendars(allCalendarsData.data);
         setTotalCount(allCalendarsData.count ?? allCalendarsData.data.length);
         setCurrentPage(1);
+        setActiveSearchTerm('');
         cacheRef.current.set(cacheKey, {
           data: allCalendarsData.data,
           totalCount: allCalendarsData.count ?? allCalendarsData.data.length,
@@ -233,6 +244,7 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
           timestamp: Date.now(),
         });
       } else {
+        setActiveSearchTerm('');
         loadPage(1, '', false);
       }
     } else {
@@ -252,6 +264,7 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
       }
       setSearchInput('');
       setSearchQuery('');
+      setActiveSearchTerm('');
       inFlightPageKeysRef.current.clear();
       loadedPageKeysRef.current.clear();
       setCalendars([]);

--- a/src/components/Dropdown/Calendar/Calendar.jsx
+++ b/src/components/Dropdown/Calendar/Calendar.jsx
@@ -265,9 +265,9 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
       setSearchInput('');
       setSearchQuery('');
       setActiveSearchTerm('');
+      loadingMoreRef.current = false;
       inFlightPageKeysRef.current.clear();
       loadedPageKeysRef.current.clear();
-      setCalendars([]);
       setTotalCount(0);
       setCurrentPage(1);
     }

--- a/src/components/Dropdown/Calendar/Calendar.jsx
+++ b/src/components/Dropdown/Calendar/Calendar.jsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { useDebounce } from '../../../hooks/debounce';
 import { SEARCH_DELAY } from '../../../constants/search';
 import { useLazyGetAllCalendarsQuery } from '../../../services/calendar';
+import { setRecentCalendarForUser } from '../../../utils/recentCalendarStorage';
 import LoadingIndicator from '../../LoadingIndicator';
 
 const hashString = (value = '') => {
@@ -281,6 +282,7 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
   const handleItemClick = (key) => {
     if (calendarIdInCookies !== key) {
       dispatch(setSelectedCalendar(String(key)));
+      setRecentCalendarForUser({ user, calendarId: key });
       sessionStorage.setItem('calendarId', key);
       setPageNumber(1);
       sessionStorage.clear();

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import './dashboard.css';
 import { Grid, Layout, Row, Col } from 'antd';
 import { Outlet, useLocation, useSearchParams } from 'react-router-dom';
@@ -25,6 +25,7 @@ import { calendarModes } from '../../constants/calendarModes';
 import { useAuth } from '../../hooks/useAuth';
 import { clearErrors, getErrorDetails } from '../../redux/reducer/ErrorSlice';
 import LoadingIndicator from '../../components/LoadingIndicator/LoadingIndicator';
+import { getRecentCalendarForUser, setRecentCalendarForUser } from '../../utils/recentCalendarStorage';
 
 const { Header, Content } = Layout;
 const { useBreakpoint } = Grid;
@@ -49,7 +50,6 @@ function Dashboard() {
 
   const {
     currentData: allCalendarsData,
-    isLoading,
     isSuccess,
     refetch,
   } = useGetAllCalendarsQuery(
@@ -69,6 +69,16 @@ function Dashboard() {
   const [isReadOnly, setIsReadOnly] = useState(false);
   const [isModalVisible, setIsModalVisible] = useState(false);
 
+  const persistActiveCalendar = useCallback(
+    (id) => {
+      if (!id) return;
+      sessionStorage.setItem('calendarId', id);
+      dispatch(setSelectedCalendar(id));
+      setRecentCalendarForUser({ user, calendarId: id });
+    },
+    [dispatch, user],
+  );
+
   useEffect(() => {
     if (location?.state?.previousPath?.toLowerCase() === 'login') {
       dispatch(setInterfaceLanguage(user?.interfaceLanguage?.toLowerCase()));
@@ -79,9 +89,9 @@ function Dashboard() {
   useEffect(() => {
     const accessTokenFromCookie = Cookies.get('accessToken');
     const refreshTokenFromCookie = Cookies.get('refreshToken');
-    const calendarIdFromCookie = sessionStorage.getItem('calendarId');
+    const calendarIdFromSessionStorage = sessionStorage.getItem('calendarId');
 
-    const calId = calendarId || calendarIdFromCookie;
+    const calId = calendarId || calendarIdFromSessionStorage;
     if (calendarId) sessionStorage.setItem('calendarId', calId);
 
     if (!checkToken(accessToken, accessTokenFromCookie)) navigate(PathName.Login);
@@ -113,8 +123,7 @@ function Dashboard() {
       getCalendar({ id: calendarId, sessionId: timestampRef })
         .unwrap()
         .then((response) => {
-          sessionStorage.setItem('calendarId', calendarId);
-          dispatch(setSelectedCalendar(String(calendarId)));
+          persistActiveCalendar(calendarId);
           if (response?.mode === calendarModes.READ_ONLY) {
             setIsReadOnly(true);
             setIsModalVisible(true);
@@ -126,16 +135,47 @@ function Dashboard() {
           }
         });
     } else {
-      let activeCalendarId = sessionStorage.getItem('calendarId');
-      if (activeCalendarId && accessToken) {
-        navigate(`${PathName.Dashboard}/${activeCalendarId}${PathName.Events}`);
-      } else if (!isLoading && allCalendarsData?.data) {
-        activeCalendarId = allCalendarsData?.data[0]?.id;
-        sessionStorage.setItem('calendarId', activeCalendarId);
-        navigate(`${PathName.Dashboard}/${activeCalendarId}${PathName.Events}`);
-      }
+      const resolveAndNavigateToCalendar = async () => {
+        const recentCalendarId = getRecentCalendarForUser(user);
+        if (recentCalendarId) {
+          try {
+            await getCalendar({ id: recentCalendarId, sessionId: timestampRef }).unwrap();
+            persistActiveCalendar(recentCalendarId);
+            navigate(`${PathName.Dashboard}/${recentCalendarId}${PathName.Events}`);
+            return;
+          } catch {
+            // Ignore stale/inaccessible stored recent ID and continue with legacy fallback.
+          }
+        }
+
+        let activeCalendarId = sessionStorage.getItem('calendarId');
+
+        if (activeCalendarId && accessToken) {
+          persistActiveCalendar(activeCalendarId);
+          navigate(`${PathName.Dashboard}/${activeCalendarId}${PathName.Events}`);
+          return;
+        }
+
+        const firstCalendarId = allCalendarsData?.data?.[0]?.id;
+        if (!firstCalendarId) return;
+
+        persistActiveCalendar(firstCalendarId);
+        navigate(`${PathName.Dashboard}/${firstCalendarId}${PathName.Events}`);
+      };
+
+      resolveAndNavigateToCalendar();
     }
-  }, [calendarId, isLoading, allCalendarsData, isSuccess]);
+  }, [
+    accessToken,
+    allCalendarsData,
+    calendarId,
+    getCalendar,
+    isSuccess,
+    navigate,
+    persistActiveCalendar,
+    timestampRef,
+    user,
+  ]);
 
   useEffect(() => {
     if (reloadStatus) {

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -80,22 +80,16 @@ const Login = () => {
     }
 
     const savedAccessToken = Cookies.get('accessToken');
-    const calenderId = sessionStorage.getItem('calendarId');
     if (location?.state?.previousPath === 'logout') {
       dispatch(clearUser());
     }
-    if (
-      ((accessToken && accessToken != '') || (savedAccessToken && savedAccessToken != '')) &&
-      calenderId &&
-      calenderId != ''
-    ) {
+    if ((accessToken && accessToken != '') || (savedAccessToken && savedAccessToken != '')) {
       navigate(PathName.Dashboard, { state: { previousPath: 'login' } });
     }
   }, []);
 
   useEffect(() => {
-    const calenderId = sessionStorage.getItem('calendarId');
-    if (accessToken && accessToken != '' && calenderId && calenderId != '') {
+    if (accessToken && accessToken != '') {
       navigate(PathName.Dashboard, { state: { previousPath: 'login' } });
     }
   }, [accessToken]);

--- a/src/utils/recentCalendarStorage.js
+++ b/src/utils/recentCalendarStorage.js
@@ -9,19 +9,27 @@ const getSafeLocalStorage = () => {
 };
 
 const getUserIdentity = (user) => {
-  if (!user) return 'anonymous';
+  if (!user) return '';
 
-  return user?.id || 'unknown-user';
+  return user?.id ? String(user.id).trim() : '';
 };
 
-const getRecentCalendarStorageKey = (user) => `${RECENT_CALENDAR_STORAGE_PREFIX}:${getUserIdentity(user)}`;
+const getRecentCalendarStorageKey = (user) => {
+  const identity = getUserIdentity(user);
+  if (!identity) return '';
+
+  return `${RECENT_CALENDAR_STORAGE_PREFIX}:${identity}`;
+};
 
 export const getRecentCalendarForUser = (user) => {
   const storage = getSafeLocalStorage();
   if (!storage) return '';
 
+  const storageKey = getRecentCalendarStorageKey(user);
+  if (!storageKey) return '';
+
   try {
-    const value = storage.getItem(getRecentCalendarStorageKey(user));
+    const value = storage.getItem(storageKey);
     if (!value) return '';
     return String(value);
   } catch {
@@ -35,8 +43,11 @@ export const setRecentCalendarForUser = ({ user, calendarId }) => {
   const storage = getSafeLocalStorage();
   if (!storage) return;
 
+  const storageKey = getRecentCalendarStorageKey(user);
+  if (!storageKey) return;
+
   try {
-    storage.setItem(getRecentCalendarStorageKey(user), String(calendarId));
+    storage.setItem(storageKey, String(calendarId));
   } catch {
     // Ignore storage failures (private mode/quota) and keep runtime behavior unchanged.
   }
@@ -46,8 +57,11 @@ export const clearRecentCalendarForUser = (user) => {
   const storage = getSafeLocalStorage();
   if (!storage) return;
 
+  const storageKey = getRecentCalendarStorageKey(user);
+  if (!storageKey) return;
+
   try {
-    storage.removeItem(getRecentCalendarStorageKey(user));
+    storage.removeItem(storageKey);
   } catch {
     // Ignore storage failures.
   }

--- a/src/utils/recentCalendarStorage.js
+++ b/src/utils/recentCalendarStorage.js
@@ -1,0 +1,54 @@
+const RECENT_CALENDAR_STORAGE_PREFIX = 'recentCalendar';
+
+const getSafeLocalStorage = () => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return null;
+  }
+
+  return window.localStorage;
+};
+
+const getUserIdentity = (user) => {
+  if (!user) return 'anonymous';
+
+  return user?.id || 'unknown-user';
+};
+
+const getRecentCalendarStorageKey = (user) => `${RECENT_CALENDAR_STORAGE_PREFIX}:${getUserIdentity(user)}`;
+
+export const getRecentCalendarForUser = (user) => {
+  const storage = getSafeLocalStorage();
+  if (!storage) return '';
+
+  try {
+    const value = storage.getItem(getRecentCalendarStorageKey(user));
+    if (!value) return '';
+    return String(value);
+  } catch {
+    return '';
+  }
+};
+
+export const setRecentCalendarForUser = ({ user, calendarId }) => {
+  if (!calendarId) return;
+
+  const storage = getSafeLocalStorage();
+  if (!storage) return;
+
+  try {
+    storage.setItem(getRecentCalendarStorageKey(user), String(calendarId));
+  } catch {
+    // Ignore storage failures (private mode/quota) and keep runtime behavior unchanged.
+  }
+};
+
+export const clearRecentCalendarForUser = (user) => {
+  const storage = getSafeLocalStorage();
+  if (!storage) return;
+
+  try {
+    storage.removeItem(getRecentCalendarStorageKey(user));
+  } catch {
+    // Ignore storage failures.
+  }
+};


### PR DESCRIPTION
This pull request introduces a new mechanism for persisting and restoring a user's most recently used calendar across sessions, improving the user experience by automatically selecting the correct calendar on login and navigation. The main changes involve adding a utility for recent calendar storage, updating the dashboard and calendar dropdown to use this utility, and simplifying the login flow.

**Recent calendar persistence and usage:**

- **Utility for recent calendar storage:**  
  Added `src/utils/recentCalendarStorage.js` with functions to set, get, and clear the recent calendar for a user using `localStorage`, handling edge cases like incognito mode and missing user info.

- **Dashboard calendar selection logic:**  
  Refactored `Dashboard.jsx` to use the recent calendar utility. On navigation, the app first tries to restore the most recently used calendar for the user, falling back to session storage or the first available calendar. Calendar selection is now encapsulated in a `persistActiveCalendar` callback, which updates session storage, Redux state, and the recent calendar utility. [[1]](diffhunk://#diff-a91c06ef87a2c02f8096a51f629429f755040ade04197c8035500609fd70ab2aR28) [[2]](diffhunk://#diff-a91c06ef87a2c02f8096a51f629429f755040ade04197c8035500609fd70ab2aR72-R81) [[3]](diffhunk://#diff-a91c06ef87a2c02f8096a51f629429f755040ade04197c8035500609fd70ab2aL116-R126) [[4]](diffhunk://#diff-a91c06ef87a2c02f8096a51f629429f755040ade04197c8035500609fd70ab2aR138-R178)

**Calendar dropdown improvements:**

- **Recent calendar update on selection:**  
  When a user selects a calendar in the dropdown, the recent calendar utility is updated, ensuring the latest selection is persisted.

- **Search and pagination state management:**  
  Improved state handling for calendar search and pagination in `Calendar.jsx` by introducing `activeSearchTerm` and resetting it appropriately, ensuring consistent results and cache management. [[1]](diffhunk://#diff-1dc069df08b5b3669fab0bf9cc476d9da6eb681c1d8404f024e35845be6cc8d4R62) [[2]](diffhunk://#diff-1dc069df08b5b3669fab0bf9cc476d9da6eb681c1d8404f024e35845be6cc8d4R196-R210) [[3]](diffhunk://#diff-1dc069df08b5b3669fab0bf9cc476d9da6eb681c1d8404f024e35845be6cc8d4R235-R248) [[4]](diffhunk://#diff-1dc069df08b5b3669fab0bf9cc476d9da6eb681c1d8404f024e35845be6cc8d4R268-L257)

**Login flow simplification:**

- **Streamlined login navigation:**  
  The login page no longer checks for a calendar ID in session storage before redirecting to the dashboard, relying instead on the dashboard's improved logic for calendar selection.

These changes collectively provide a more seamless and robust calendar selection experience for users, with improved persistence and fewer edge-case failures.