### PR TITLE
Bugfix/issue 2263

### DIFF
--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -2022,8 +2022,6 @@ function AddEvent() {
         })
         .catch((error) => console.log(error));
 
-    // When the event is still published, revert it to draft first and wait for the
-    // backend to complete the transition; saving while published returns a 409 conflict.
     if (eventId && eventData?.publishState === eventPublishState.PUBLISHED) {
       updateEventState({ id: eventId, calendarId, publishState: eventPublishState.DRAFT })
         .unwrap()

--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -616,7 +616,7 @@ function AddEvent() {
         Object.keys(errors).map((fieldName) => ({
           name: fieldName,
           errors: errors[fieldName].errors,
-          value: data,
+          value: errors[fieldName].value,
         })),
       );
     }

--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -1969,54 +1969,69 @@ function AddEvent() {
   };
 
   const organizerPerformerSupporterPlaceNavigationHandler = (id, type, event) => {
-    saveAsDraftHandler(event, true, eventPublishState.DRAFT)
-      .then((savedEventId) => {
-        if ((!eventId || eventId === '') && newEventId === null)
-          notification.success({
-            description: t('dashboard.events.addEditEvent.notification.saveAsDraft'),
-            placement: 'top',
-            closeIcon: <></>,
-            maxCount: 1,
-            duration: 3,
-          });
-        else
-          notification.success({
-            description: t('dashboard.events.addEditEvent.notification.updateEvent'),
-            placement: 'top',
-            closeIcon: <></>,
-            maxCount: 1,
-            duration: 3,
-          });
+    const saveAndNavigate = () =>
+      saveAsDraftHandler(event, true, eventPublishState.DRAFT)
+        .then((savedEventId) => {
+          if ((!eventId || eventId === '') && newEventId === null)
+            notification.success({
+              description: t('dashboard.events.addEditEvent.notification.saveAsDraft'),
+              placement: 'top',
+              closeIcon: <></>,
+              maxCount: 1,
+              duration: 3,
+            });
+          else
+            notification.success({
+              description: t('dashboard.events.addEditEvent.notification.updateEvent'),
+              placement: 'top',
+              closeIcon: <></>,
+              maxCount: 1,
+              duration: 3,
+            });
 
-        if (type?.toUpperCase() == taxonomyClass.ORGANIZATION)
-          navigate(`${PathName.Dashboard}/${calendarId}${PathName.Organizations}${PathName.AddOrganization}?id=${id}`, {
-            state: {
-              data: {
-                isRoutingToEventPage: eventId ? location.pathname : `${location.pathname}/${savedEventId}`,
-                shouldValidateOnOpen: true,
+          if (type?.toUpperCase() == taxonomyClass.ORGANIZATION)
+            navigate(
+              `${PathName.Dashboard}/${calendarId}${PathName.Organizations}${PathName.AddOrganization}?id=${id}`,
+              {
+                state: {
+                  data: {
+                    isRoutingToEventPage: eventId ? location.pathname : `${location.pathname}/${savedEventId}`,
+                    shouldValidateOnOpen: true,
+                  },
+                },
               },
-            },
-          });
-        else if (type?.toUpperCase() == taxonomyClass.PERSON)
-          navigate(`${PathName.Dashboard}/${calendarId}${PathName.People}${PathName.AddPerson}?id=${id}`, {
-            state: {
-              data: {
-                isRoutingToEventPage: eventId ? location.pathname : `${location.pathname}/${savedEventId}`,
-                shouldValidateOnOpen: true,
+            );
+          else if (type?.toUpperCase() == taxonomyClass.PERSON)
+            navigate(`${PathName.Dashboard}/${calendarId}${PathName.People}${PathName.AddPerson}?id=${id}`, {
+              state: {
+                data: {
+                  isRoutingToEventPage: eventId ? location.pathname : `${location.pathname}/${savedEventId}`,
+                  shouldValidateOnOpen: true,
+                },
               },
-            },
-          });
-        else if (type?.toUpperCase() == taxonomyClass.PLACE)
-          navigate(`${PathName.Dashboard}/${calendarId}${PathName.Places}${PathName.AddPlace}?id=${id}`, {
-            state: {
-              data: {
-                isRoutingToEventPage: eventId ? location.pathname : `${location.pathname}/${savedEventId}`,
-                shouldValidateOnOpen: true,
+            });
+          else if (type?.toUpperCase() == taxonomyClass.PLACE)
+            navigate(`${PathName.Dashboard}/${calendarId}${PathName.Places}${PathName.AddPlace}?id=${id}`, {
+              state: {
+                data: {
+                  isRoutingToEventPage: eventId ? location.pathname : `${location.pathname}/${savedEventId}`,
+                  shouldValidateOnOpen: true,
+                },
               },
-            },
-          });
-      })
-      .catch((error) => console.log(error));
+            });
+        })
+        .catch((error) => console.log(error));
+
+    // When the event is still published, revert it to draft first and wait for the
+    // backend to complete the transition; saving while published returns a 409 conflict.
+    if (eventId && eventData?.publishState === eventPublishState.PUBLISHED) {
+      updateEventState({ id: eventId, calendarId, publishState: eventPublishState.DRAFT })
+        .unwrap()
+        .then(() => saveAndNavigate())
+        .catch((error) => console.log(error));
+    } else {
+      saveAndNavigate();
+    }
   };
   const FeaturedJSX = (
     <Row justify={'start'} align={'top'} gutter={[8, 0]}>


### PR DESCRIPTION
This pull request makes several improvements to the `AddEvent` page, primarily focusing on navigation logic, event state management, and form error handling. The changes ensure that navigation to related entities (like organizations) works more reliably, and that events are properly saved as drafts before navigating away, especially when editing published events.

**Navigation and event state management:**

* The `organizerPerformerSupporterPlaceNavigationHandler` function now checks if the event is published, and if so, updates its state to draft before continuing navigation. This ensures edits are not lost and the event is in the correct state before navigating away.
* The navigation to the "Add Organization" page is now wrapped in a multi-line call for clarity, and the navigation state is passed more explicitly, improving maintainability and readability.

**Form error handling:**

* The error mapping logic now correctly uses the value from `errors[fieldName].value` instead of the entire `data` object, ensuring form fields display the correct error values.

**Code structure improvements:**

* The navigation handler's logic for saving and navigating has been refactored into a `saveAndNavigate` function for better readability and reusability.