### PR TITLE
Normalize sameAs URI for read-only entity links

### DIFF
--- a/src/pages/Dashboard/OrganizationsReadOnly/OrganizationsReadOnly.jsx
+++ b/src/pages/Dashboard/OrganizationsReadOnly/OrganizationsReadOnly.jsx
@@ -26,7 +26,7 @@ import TreeSelectOption from '../../../components/TreeSelectOption/TreeSelectOpt
 import FeatureFlag from '../../../layout/FeatureFlag/FeatureFlag';
 import { featureFlags } from '../../../utils/featureFlags';
 import ArtsDataInfo from '../../../components/ArtsDataInfo/ArtsDataInfo';
-import { artsDataLinkChecker } from '../../../utils/artsDataLinkChecker';
+import { artsDataLinkChecker, createArtsDataLink } from '../../../utils/artsDataLinkChecker';
 import Breadcrumbs from '../../../components/Breadcrumbs';
 import ReadOnlyProtectedComponent from '../../../layout/ReadOnlyProtectedComponent';
 import { loadArtsDataEntity } from '../../../services/artsData';
@@ -368,7 +368,7 @@ function OrganizationsReadOnly() {
                     </div>
                   ) : artsData ? (
                     <ArtsDataInfo
-                      artsDataLink={artsDataLinkChecker(organizationData?.sameAs)}
+                      artsDataLink={createArtsDataLink(artsDataLinkChecker(organizationData?.sameAs))}
                       name={contentLanguageBilingual({
                         data: artsData?.name,
                         requiredLanguageKey: user?.interfaceLanguage?.toLowerCase(),

--- a/src/pages/Dashboard/PersonReadOnly/PersonReadOnly.jsx
+++ b/src/pages/Dashboard/PersonReadOnly/PersonReadOnly.jsx
@@ -24,7 +24,7 @@ import FeatureFlag from '../../../layout/FeatureFlag/FeatureFlag';
 import { featureFlags } from '../../../utils/featureFlags';
 import { useGetPersonQuery } from '../../../services/people';
 import ArtsDataInfo from '../../../components/ArtsDataInfo/ArtsDataInfo';
-import { artsDataLinkChecker } from '../../../utils/artsDataLinkChecker';
+import { artsDataLinkChecker, createArtsDataLink } from '../../../utils/artsDataLinkChecker';
 import Breadcrumbs from '../../../components/Breadcrumbs/Breadcrumbs';
 import { taxonomyDetails } from '../../../utils/taxonomyDetails';
 import ReadOnlyProtectedComponent from '../../../layout/ReadOnlyProtectedComponent';
@@ -318,7 +318,7 @@ function PersonReadOnly() {
                     </div>
                   ) : artsData ? (
                     <ArtsDataInfo
-                      artsDataLink={artsDataLinkChecker(personData?.sameAs)}
+                      artsDataLink={createArtsDataLink(artsDataLinkChecker(personData?.sameAs))}
                       name={contentLanguageBilingual({
                         data: artsData?.name,
                         requiredLanguageKey: user?.interfaceLanguage?.toLowerCase(),

--- a/src/pages/Dashboard/PlaceReadOnly/PlaceReadOnly.jsx
+++ b/src/pages/Dashboard/PlaceReadOnly/PlaceReadOnly.jsx
@@ -28,7 +28,7 @@ import SelectionItem from '../../../components/List/SelectionItem/SelectionItem'
 import Alert from '../../../components/Alert';
 import { placesOptions } from '../../../components/Select/selectOption.settings';
 import ArtsDataInfo from '../../../components/ArtsDataInfo/ArtsDataInfo';
-import { artsDataLinkChecker } from '../../../utils/artsDataLinkChecker';
+import { artsDataLinkChecker, createArtsDataLink } from '../../../utils/artsDataLinkChecker';
 import Breadcrumbs from '../../../components/Breadcrumbs/Breadcrumbs';
 import ReadOnlyProtectedComponent from '../../../layout/ReadOnlyProtectedComponent';
 import { loadArtsDataPlaceEntity } from '../../../services/artsData';
@@ -388,7 +388,7 @@ function PlaceReadOnly() {
                     </div>
                   ) : artsData ? (
                     <ArtsDataInfo
-                      artsDataLink={artsDataLinkChecker(placeData?.sameAs)}
+                      artsDataLink={createArtsDataLink(artsDataLinkChecker(placeData?.sameAs))}
                       name={contentLanguageBilingual({
                         data: artsData?.name,
                         requiredLanguageKey: user?.interfaceLanguage?.toLowerCase(),

--- a/src/utils/artsDataLinkChecker.js
+++ b/src/utils/artsDataLinkChecker.js
@@ -3,7 +3,9 @@ import { sameAsTypes } from '../constants/sameAsTypes';
 export const artsDataLinkChecker = (link) => {
   const artsData = 'artsdata';
   if (Array.isArray(link)) {
-    const artsDataLink = link?.find((item) => item?.type === sameAsTypes.ARTSDATA_IDENTIFIER)?.uri;
+    const artsDataLink = link?.find(
+      (item) => item?.type === sameAsTypes.ARTSDATA_IDENTIFIER && isArtsdataUri(item?.uri),
+    )?.uri;
     if (artsDataLink) {
       return artsDataLink;
     }


### PR DESCRIPTION
This pull request refactors how the `artsDataLink` prop is constructed for the `ArtsDataInfo` component across the read-only dashboard pages for organizations, people, and places. The main change is the introduction of the `createArtsDataLink` function, which now wraps the result of `artsDataLinkChecker` before passing it to `ArtsDataInfo`. This improves consistency and likely encapsulates additional logic for link creation.

### Refactoring of ArtsData Link Construction

* Updated imports in `OrganizationsReadOnly.jsx`, `PersonReadOnly.jsx`, and `PlaceReadOnly.jsx` to include the new `createArtsDataLink` utility function alongside `artsDataLinkChecker`. [[1]](diffhunk://#diff-ab29b0f47c3df2cc6fb0f1d9c63b6c8caa0852eb89aea676b7d0866096eb314dL29-R29) [[2]](diffhunk://#diff-0954dabb20fc49791c50419f2ddd674b447de0ade35b39fce5e8555015034c40L27-R27) [[3]](diffhunk://#diff-c24ea32e1a40dd241c1a7b03f5dd557344450f6c2bf80c867feb314bc400bbb6L31-R31)
* Changed the `artsDataLink` prop passed to `ArtsDataInfo` in all three read-only pages to use `createArtsDataLink(artsDataLinkChecker(...))` instead of just `artsDataLinkChecker(...)`. [[1]](diffhunk://#diff-ab29b0f47c3df2cc6fb0f1d9c63b6c8caa0852eb89aea676b7d0866096eb314dL371-R371) [[2]](diffhunk://#diff-0954dabb20fc49791c50419f2ddd674b447de0ade35b39fce5e8555015034c40L321-R321) [[3]](diffhunk://#diff-c24ea32e1a40dd241c1a7b03f5dd557344450f6c2bf80c867feb314bc400bbb6L391-R391)