### PR TITLE
Fix event editing and validation error handling

### DIFF
--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -2022,8 +2022,6 @@ function AddEvent() {
         })
         .catch((error) => console.log(error));
 
-    // When the event is still published, revert it to draft first and wait for the
-    // backend to complete the transition; saving while published returns a 409 conflict.
     if (eventId && eventData?.publishState === eventPublishState.PUBLISHED) {
       updateEventState({ id: eventId, calendarId, publishState: eventPublishState.DRAFT })
         .unwrap()

--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -616,7 +616,7 @@ function AddEvent() {
         Object.keys(errors).map((fieldName) => ({
           name: fieldName,
           errors: errors[fieldName].errors,
-          value: data,
+          value: errors[fieldName].value,
         })),
       );
     }

--- a/src/pages/Dashboard/AddEvent/AddEvent.jsx
+++ b/src/pages/Dashboard/AddEvent/AddEvent.jsx
@@ -1969,54 +1969,69 @@ function AddEvent() {
   };
 
   const organizerPerformerSupporterPlaceNavigationHandler = (id, type, event) => {
-    saveAsDraftHandler(event, true, eventPublishState.DRAFT)
-      .then((savedEventId) => {
-        if ((!eventId || eventId === '') && newEventId === null)
-          notification.success({
-            description: t('dashboard.events.addEditEvent.notification.saveAsDraft'),
-            placement: 'top',
-            closeIcon: <></>,
-            maxCount: 1,
-            duration: 3,
-          });
-        else
-          notification.success({
-            description: t('dashboard.events.addEditEvent.notification.updateEvent'),
-            placement: 'top',
-            closeIcon: <></>,
-            maxCount: 1,
-            duration: 3,
-          });
+    const saveAndNavigate = () =>
+      saveAsDraftHandler(event, true, eventPublishState.DRAFT)
+        .then((savedEventId) => {
+          if ((!eventId || eventId === '') && newEventId === null)
+            notification.success({
+              description: t('dashboard.events.addEditEvent.notification.saveAsDraft'),
+              placement: 'top',
+              closeIcon: <></>,
+              maxCount: 1,
+              duration: 3,
+            });
+          else
+            notification.success({
+              description: t('dashboard.events.addEditEvent.notification.updateEvent'),
+              placement: 'top',
+              closeIcon: <></>,
+              maxCount: 1,
+              duration: 3,
+            });
 
-        if (type?.toUpperCase() == taxonomyClass.ORGANIZATION)
-          navigate(`${PathName.Dashboard}/${calendarId}${PathName.Organizations}${PathName.AddOrganization}?id=${id}`, {
-            state: {
-              data: {
-                isRoutingToEventPage: eventId ? location.pathname : `${location.pathname}/${savedEventId}`,
-                shouldValidateOnOpen: true,
+          if (type?.toUpperCase() == taxonomyClass.ORGANIZATION)
+            navigate(
+              `${PathName.Dashboard}/${calendarId}${PathName.Organizations}${PathName.AddOrganization}?id=${id}`,
+              {
+                state: {
+                  data: {
+                    isRoutingToEventPage: eventId ? location.pathname : `${location.pathname}/${savedEventId}`,
+                    shouldValidateOnOpen: true,
+                  },
+                },
               },
-            },
-          });
-        else if (type?.toUpperCase() == taxonomyClass.PERSON)
-          navigate(`${PathName.Dashboard}/${calendarId}${PathName.People}${PathName.AddPerson}?id=${id}`, {
-            state: {
-              data: {
-                isRoutingToEventPage: eventId ? location.pathname : `${location.pathname}/${savedEventId}`,
-                shouldValidateOnOpen: true,
+            );
+          else if (type?.toUpperCase() == taxonomyClass.PERSON)
+            navigate(`${PathName.Dashboard}/${calendarId}${PathName.People}${PathName.AddPerson}?id=${id}`, {
+              state: {
+                data: {
+                  isRoutingToEventPage: eventId ? location.pathname : `${location.pathname}/${savedEventId}`,
+                  shouldValidateOnOpen: true,
+                },
               },
-            },
-          });
-        else if (type?.toUpperCase() == taxonomyClass.PLACE)
-          navigate(`${PathName.Dashboard}/${calendarId}${PathName.Places}${PathName.AddPlace}?id=${id}`, {
-            state: {
-              data: {
-                isRoutingToEventPage: eventId ? location.pathname : `${location.pathname}/${savedEventId}`,
-                shouldValidateOnOpen: true,
+            });
+          else if (type?.toUpperCase() == taxonomyClass.PLACE)
+            navigate(`${PathName.Dashboard}/${calendarId}${PathName.Places}${PathName.AddPlace}?id=${id}`, {
+              state: {
+                data: {
+                  isRoutingToEventPage: eventId ? location.pathname : `${location.pathname}/${savedEventId}`,
+                  shouldValidateOnOpen: true,
+                },
               },
-            },
-          });
-      })
-      .catch((error) => console.log(error));
+            });
+        })
+        .catch((error) => console.log(error));
+
+    // When the event is still published, revert it to draft first and wait for the
+    // backend to complete the transition; saving while published returns a 409 conflict.
+    if (eventId && eventData?.publishState === eventPublishState.PUBLISHED) {
+      updateEventState({ id: eventId, calendarId, publishState: eventPublishState.DRAFT })
+        .unwrap()
+        .then(() => saveAndNavigate())
+        .catch((error) => console.log(error));
+    } else {
+      saveAndNavigate();
+    }
   };
   const FeaturedJSX = (
     <Row justify={'start'} align={'top'} gutter={[8, 0]}>


### PR DESCRIPTION
This pull request makes several improvements to the `AddEvent` functionality in `src/pages/Dashboard/AddEvent/AddEvent.jsx`. The main changes enhance navigation logic, improve error handling, and ensure events are properly saved as drafts before navigation. The most important changes are:

**Navigation and Event State Handling:**

* Refactored the navigation logic for organizers to ensure that when navigating to add an organization, the navigation call is formatted for better readability and maintainability.
* Updated the `organizerPerformerSupporterPlaceNavigationHandler` to check if an event is published, and if so, update its state to draft before proceeding with navigation. This ensures that edits are not made to published events without first saving them as drafts.
* Introduced a `saveAndNavigate` helper function to encapsulate the logic for saving an event as a draft and then navigating, reducing code duplication and improving clarity.

**Error Handling:**

* Corrected the mapping of error values so that each field's error now references the correct value from the `errors` object, instead of the entire data object.