### PR TITLE
Enhance delete confirmation modal and impacted entities report

### DIFF
--- a/src/components/Modal/Confirm/Confirm.jsx
+++ b/src/components/Modal/Confirm/Confirm.jsx
@@ -4,6 +4,7 @@ import './confirm.css';
 
 export const Confirm = ({ title, content, onCancel, onAction, okText, cancelText, className, closable }) => {
   const { confirm } = Modal;
+  const isStringContent = typeof content === 'string';
 
   let modalClassName = ['global-delete-modal-container'];
   if (className) {
@@ -20,7 +21,7 @@ export const Confirm = ({ title, content, onCancel, onAction, okText, cancelText
     content: (
       <div style={{ padding: '24px' }}>
         <ExclamationCircleOutlined size="18px" />
-        <span style={{ fontSize: '16px' }}>{content}</span>
+        {isStringContent ? <span style={{ fontSize: '16px' }}>{content}</span> : content}
       </div>
     ),
     icon: null,

--- a/src/components/Modal/Confirm/Confirm.jsx
+++ b/src/components/Modal/Confirm/Confirm.jsx
@@ -21,7 +21,7 @@ export const Confirm = ({ title, content, onCancel, onAction, okText, cancelText
     content: (
       <div style={{ padding: '24px' }}>
         <ExclamationCircleOutlined size="18px" />
-        {isStringContent ? <span style={{ fontSize: '16px' }}>{content}</span> : content}
+        {isStringContent ? <span>{content}</span> : content}
       </div>
     ),
     icon: null,

--- a/src/components/Modal/Confirm/confirm.css
+++ b/src/components/Modal/Confirm/confirm.css
@@ -87,7 +87,8 @@
   line-height: 24px; /* 150% */
 }
 
-.global-delete-modal-container .ant-modal-confirm-btns button:first-child {
+.global-delete-modal-container .ant-modal-confirm-btns button:first-child,
+.global-delete-modal-container .confirm-footer-secondary-btn {
   border-radius: 4px;
   background: var(--background-neutrals-transparent, rgba(255, 255, 255, 0));
   border: none;
@@ -97,4 +98,58 @@
   font-style: normal;
   font-weight: 600;
   line-height: 24px; /* 150% */
+}
+
+.taxonomy-delete-modal-container .taxonomy-delete-modal-content-wrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.taxonomy-delete-modal-container .taxonomy-delete-modal-bottom-actions {
+  position: absolute;
+  bottom: 16px;
+  left: 16px;
+  z-index: 2;
+  height: 40px;
+  display: flex;
+  align-items: center;
+}
+
+.taxonomy-delete-modal-container .taxonomy-delete-modal-bottom-actions .outlined-button.ant-btn {
+  height: 40px;
+  padding: 8px 16px;
+  margin: 0;
+  align-items: center;
+}
+
+.taxonomy-delete-modal-container .taxonomy-delete-modal-bottom-actions .outlined-label {
+  color: var(--content-action-default, #1b3de6) !important;
+}
+
+.taxonomy-delete-modal-container .ant-modal-content {
+  position: relative;
+}
+
+@media only screen and (max-width: 575px) {
+  .taxonomy-delete-modal-container .ant-modal-confirm-btns {
+    height: auto;
+    min-height: 120px;
+    padding: 16px;
+    align-items: flex-start;
+  }
+
+  .taxonomy-delete-modal-container .taxonomy-delete-modal-bottom-actions {
+    position: absolute;
+    left: 16px;
+    right: 16px;
+    bottom: 16px;
+    height: auto;
+    margin-top: 0;
+  }
+
+  .taxonomy-delete-modal-container .taxonomy-delete-modal-bottom-actions .outlined-button.ant-btn {
+    width: 100%;
+    justify-content: center;
+  }
 }

--- a/src/components/Modal/Confirm/confirm.css
+++ b/src/components/Modal/Confirm/confirm.css
@@ -10,6 +10,7 @@
 
 .global-delete-modal-container .ant-modal-content {
   border-radius: 8px !important;
+  position: relative;
 }
 
 .global-delete-modal-container .ant-modal-body {
@@ -43,16 +44,18 @@
   gap: 8px;
   border-radius: 4px;
   background: #ffcfcf;
+  color: var(--content-alert-error-darker, #ce1111);
   padding: 16px;
 }
 
-.global-delete-modal-container .ant-modal-confirm-content > div :first-child {
+.global-delete-modal-container .ant-modal-confirm-content > div > span:first-of-type {
   display: flex;
   align-items: flex-start;
   justify-content: center;
   margin-top: 2px;
 }
-.global-delete-modal-container .ant-modal-confirm-content > div :last-child {
+
+.global-delete-modal-container .ant-modal-confirm-content > div > span:last-of-type {
   color: var(--content-alert-error-darker, #ce1111);
   font-family: Helvetica;
   font-size: 18px;
@@ -87,8 +90,7 @@
   line-height: 24px; /* 150% */
 }
 
-.global-delete-modal-container .ant-modal-confirm-btns button:first-child,
-.global-delete-modal-container .confirm-footer-secondary-btn {
+.global-delete-modal-container .ant-modal-confirm-btns button:first-child {
   border-radius: 4px;
   background: var(--background-neutrals-transparent, rgba(255, 255, 255, 0));
   border: none;
@@ -100,56 +102,49 @@
   line-height: 24px; /* 150% */
 }
 
-.taxonomy-delete-modal-container .taxonomy-delete-modal-content-wrapper {
+.global-delete-modal-container .taxonomy-delete-modal-content-wrapper {
   display: flex;
   flex-direction: column;
   width: 100%;
 }
 
-.taxonomy-delete-modal-container .taxonomy-delete-modal-bottom-actions {
+.global-delete-modal-container .taxonomy-delete-modal-bottom-actions {
   position: absolute;
   bottom: 16px;
   left: 16px;
-  z-index: 2;
-  height: 40px;
   display: flex;
-  align-items: center;
 }
 
-.taxonomy-delete-modal-container .taxonomy-delete-modal-bottom-actions .outlined-button.ant-btn {
-  height: 40px;
-  padding: 8px 16px;
+.global-delete-modal-container .taxonomy-delete-modal-bottom-actions .outlined-button.ant-btn {
+  height: 38px;
   margin: 0;
-  align-items: center;
 }
 
-.taxonomy-delete-modal-container .taxonomy-delete-modal-bottom-actions .outlined-label {
-  color: var(--content-action-default, #1b3de6) !important;
+.global-delete-modal-container .taxonomy-delete-modal-bottom-actions .outlined-label {
+  color: var(--content-action-default, #1b3de6);
 }
 
-.taxonomy-delete-modal-container .ant-modal-content {
-  position: relative;
-}
-
-@media only screen and (max-width: 575px) {
-  .taxonomy-delete-modal-container .ant-modal-confirm-btns {
+@media only screen and (max-width: 400px) {
+  .global-delete-modal-container .ant-modal-confirm-btns {
     height: auto;
-    min-height: 120px;
+    min-height: 104px;
     padding: 16px;
     align-items: flex-start;
   }
 
-  .taxonomy-delete-modal-container .taxonomy-delete-modal-bottom-actions {
+  .global-delete-modal-container .taxonomy-delete-modal-bottom-actions {
     position: absolute;
     left: 16px;
     right: 16px;
-    bottom: 16px;
-    height: auto;
-    margin-top: 0;
+    bottom: 8px;
   }
 
-  .taxonomy-delete-modal-container .taxonomy-delete-modal-bottom-actions .outlined-button.ant-btn {
+  .global-delete-modal-container .taxonomy-delete-modal-bottom-actions .outlined-button.ant-btn {
     width: 100%;
-    justify-content: center;
+  }
+
+  .global-delete-modal-container .taxonomy-delete-modal-bottom-actions .outlined-label {
+    font-size: 16px;
+    line-height: 24px;
   }
 }

--- a/src/locales/en/translationEn.json
+++ b/src/locales/en/translationEn.json
@@ -1255,7 +1255,10 @@
             "published": "{{number}} published",
             "inReview": "{{number}} pending review",
             "draft": "{{number}} draft",
-            "success": "Success! The taxonomy has been deleted."
+            "success": "Success! The taxonomy has been deleted.",
+            "seeImpactedEntities": "See impacted entities",
+            "noImpactedEntitiesFound": "No impacted entities found.",
+            "reportDownloadError": "Unable to download impacted entities report."
           }
         }
       },

--- a/src/locales/fr/transalationFr.json
+++ b/src/locales/fr/transalationFr.json
@@ -1251,7 +1251,10 @@
             "published": "publié - {{number}}",
             "draft": "brouillon - {{number}}",
             "inReview": "attente d'approbation - {{number}}",
-            "success": "Succès ! La taxonomie a été supprimée."
+            "success": "Succès ! La taxonomie a été supprimée.",
+            "seeImpactedEntities": "Voir les entités concernées",
+            "noImpactedEntitiesFound": "Aucune entité concernée trouvée.",
+            "reportDownloadError": "Impossible de télécharger le rapport des entités concernées."
           }
         }
       },

--- a/src/pages/Dashboard/Taxonomy/Taxonomy.jsx
+++ b/src/pages/Dashboard/Taxonomy/Taxonomy.jsx
@@ -75,14 +75,6 @@ const downloadBlob = ({ blob, filename }) => {
   window.URL.revokeObjectURL(objectUrl);
 };
 
-const readBlobAsText = async (blob) => {
-  if (!blob || blob.size === 0) {
-    return '';
-  }
-
-  return blob.text();
-};
-
 const Taxonomy = () => {
   const { calendarId } = useParams();
   const timestampRef = useRef(Date.now()).current;
@@ -108,7 +100,6 @@ const Taxonomy = () => {
   const [deleteTaxonomy, { isLoading: deleteTaxonomyLoading }] = useDeleteTaxonomyMutation();
   const [getDependencyDetails, { isFetching: dependencyDetailsFetching }] = useLazyGetEntityDependencyCountQuery();
   const [getEntityReverseLinksReport] = useLazyGetEntityReverseLinksReportQuery();
-  const [impactReportDownloadingId, setImpactReportDownloadingId] = useState(null);
 
   const sortByParam = searchParams.get('sortBy');
 
@@ -265,30 +256,53 @@ const Taxonomy = () => {
     getDependencyDetails({ ids: id, calendarId })
       .unwrap()
       .then((res) => {
+        let isDownloadingReport = false;
+        let confirmInstance;
+
+        const getDeleteConfirmContent = () => (
+          <div className="taxonomy-delete-modal-content-wrapper">
+            <p style={{ marginBottom: 0 }}>
+              {`${t('dashboard.taxonomy.listing.modal.contentDelete.description')} ${t(
+                'dashboard.taxonomy.listing.modal.contentDelete.impact',
+              )} ${t('dashboard.taxonomy.listing.modal.contentDelete.published', {
+                number: `${res?.events?.publishedEventCount}`,
+              })}, ${t('dashboard.taxonomy.listing.modal.contentDelete.draft', {
+                number: `${res?.events?.draftEventCount}`,
+              })}, ${t('dashboard.taxonomy.listing.modal.contentDelete.inReview', {
+                number: `${res?.events?.pendingEventCount}`,
+              })}.`}
+            </p>
+            <div className="taxonomy-delete-modal-bottom-actions">
+              <Outlined
+                label={t('dashboard.taxonomy.listing.modal.contentDelete.seeImpactedEntities')}
+                onClick={handleImpactedEntitiesDownload}
+                loading={isDownloadingReport}
+                disabled={isDownloadingReport}
+                data-cy="taxonomy-impacted-entities-download-btn"
+              />
+            </div>
+          </div>
+        );
+
+        const updateConfirmContent = () => {
+          confirmInstance?.update({
+            content: getDeleteConfirmContent(),
+          });
+        };
+
         const handleImpactedEntitiesDownload = async () => {
-          if (impactReportDownloadingId === id) {
+          if (isDownloadingReport) {
             return;
           }
 
-          setImpactReportDownloadingId(id);
+          isDownloadingReport = true;
+          updateConfirmContent();
 
           try {
             const response = await getEntityReverseLinksReport({ ids: [id], calendarId }).unwrap();
             const reportBlob = response?.blob;
 
             if (!reportBlob || reportBlob.size === 0) {
-              notification.info({
-                description: t('dashboard.taxonomy.listing.modal.contentDelete.noImpactedEntitiesFound'),
-                placement: 'top',
-                closeIcon: <></>,
-                maxCount: 1,
-                duration: 3,
-              });
-              return;
-            }
-
-            const reportText = await readBlobAsText(reportBlob);
-            if (!reportText.trim()) {
               notification.info({
                 description: t('dashboard.taxonomy.listing.modal.contentDelete.noImpactedEntitiesFound'),
                 placement: 'top',
@@ -306,21 +320,19 @@ const Taxonomy = () => {
             downloadBlob({ blob: reportBlob, filename });
           } catch (error) {
             notification.error({
-              description:
-                error?.data ||
-                error?.message ||
-                t('dashboard.taxonomy.listing.modal.contentDelete.reportDownloadError'),
+              description: error?.data || t('dashboard.taxonomy.listing.modal.contentDelete.reportDownloadError'),
               placement: 'top',
               closeIcon: <></>,
               maxCount: 1,
               duration: 3,
             });
           } finally {
-            setImpactReportDownloadingId(null);
+            isDownloadingReport = false;
+            updateConfirmContent();
           }
         };
 
-        Confirm({
+        confirmInstance = Confirm({
           title: t('dashboard.taxonomy.listing.modal.titleDelete'),
           onAction: () => {
             deleteTaxonomy({ id: id, calendarId: calendarId })
@@ -343,31 +355,7 @@ const Taxonomy = () => {
           },
           okText: t('dashboard.settings.addUser.delete'),
           cancelText: t('dashboard.settings.addUser.cancel'),
-          className: 'taxonomy-delete-modal-container',
-          content: (
-            <div className="taxonomy-delete-modal-content-wrapper">
-              <p style={{ marginBottom: 0 }}>
-                {`${t('dashboard.taxonomy.listing.modal.contentDelete.description')} ${t(
-                  'dashboard.taxonomy.listing.modal.contentDelete.impact',
-                )} ${t('dashboard.taxonomy.listing.modal.contentDelete.published', {
-                  number: `${res?.events?.publishedEventCount}`,
-                })}, ${t('dashboard.taxonomy.listing.modal.contentDelete.draft', {
-                  number: `${res?.events?.draftEventCount}`,
-                })}, ${t('dashboard.taxonomy.listing.modal.contentDelete.inReview', {
-                  number: `${res?.events?.pendingEventCount}`,
-                })}.`}
-              </p>
-              <div className="taxonomy-delete-modal-bottom-actions">
-                <Outlined
-                  label={t('dashboard.taxonomy.listing.modal.contentDelete.seeImpactedEntities')}
-                  onClick={handleImpactedEntitiesDownload}
-                  loading={impactReportDownloadingId === id}
-                  disabled={impactReportDownloadingId === id}
-                  data-cy="taxonomy-impacted-entities-download-btn"
-                />
-              </div>
-            </div>
-          ),
+          content: getDeleteConfirmContent(),
         });
       });
   };

--- a/src/pages/Dashboard/Taxonomy/Taxonomy.jsx
+++ b/src/pages/Dashboard/Taxonomy/Taxonomy.jsx
@@ -13,6 +13,7 @@ import { useDeleteTaxonomyMutation, useLazyGetAllTaxonomyQuery } from '../../../
 import UserSearch from '../../../components/Search/Events/EventsSearch';
 import { PathName } from '../../../constants/pathName';
 import AddEvent from '../../../components/Button/AddEvent';
+import Outlined from '../../../components/Button/Outlined/Outlined';
 import {
   SortAscendingOutlined,
   SortDescendingOutlined,
@@ -29,7 +30,10 @@ import ListItem from '../../../components/List/ListItem.jsx/ListItem';
 import { Confirm } from '../../../components/Modal/Confirm/Confirm';
 import { taxonomyClassTranslations } from '../../../constants/taxonomyClass';
 import SearchableCheckbox from '../../../components/Filter/SearchableCheckbox/SearchableCheckbox';
-import { useLazyGetEntityDependencyCountQuery } from '../../../services/entities';
+import {
+  useLazyGetEntityDependencyCountQuery,
+  useLazyGetEntityReverseLinksReportQuery,
+} from '../../../services/entities';
 import { setErrorStates } from '../../../redux/reducer/ErrorSlice';
 import { adminCheckHandler } from '../../../utils/adminCheckHandler';
 import { getCurrentCalendarDetailsFromUserDetails } from '../../../utils/getCurrentCalendarDetailsFromUserDetails';
@@ -37,6 +41,47 @@ import EntityReports from '../../../components/EntityReports/EntityReports';
 import { entitiesClass, REPORT_ACTION_KEY } from '../../../constants/entitiesClass';
 
 const { useBreakpoint } = Grid;
+
+const parseContentDispositionFilename = (contentDisposition, fallback = 'impacted-entities_report.csv') => {
+  if (!contentDisposition) return fallback;
+
+  const filenameStarMatch = contentDisposition.match(/filename\*=([^;]+)/i);
+  if (filenameStarMatch?.[1]) {
+    const rawValue = filenameStarMatch[1].trim();
+    const encodedFileName = rawValue.includes("''") ? rawValue.split("''").slice(1).join("''") : rawValue;
+    try {
+      const decoded = decodeURIComponent(encodedFileName.replace(/^"|"$/g, ''));
+      return decoded || fallback;
+    } catch (_error) {
+      // Fallback to plain filename parsing.
+    }
+  }
+
+  const filenameMatch = contentDisposition.match(/filename="?([^";]+)"?/i);
+  return filenameMatch?.[1] || fallback;
+};
+
+const downloadBlob = ({ blob, filename }) => {
+  const objectUrl = window.URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+
+  anchor.href = objectUrl;
+  anchor.download = filename;
+
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+
+  window.URL.revokeObjectURL(objectUrl);
+};
+
+const readBlobAsText = async (blob) => {
+  if (!blob || blob.size === 0) {
+    return '';
+  }
+
+  return blob.text();
+};
 
 const Taxonomy = () => {
   const { calendarId } = useParams();
@@ -62,6 +107,8 @@ const Taxonomy = () => {
   });
   const [deleteTaxonomy, { isLoading: deleteTaxonomyLoading }] = useDeleteTaxonomyMutation();
   const [getDependencyDetails, { isFetching: dependencyDetailsFetching }] = useLazyGetEntityDependencyCountQuery();
+  const [getEntityReverseLinksReport] = useLazyGetEntityReverseLinksReportQuery();
+  const [impactReportDownloadingId, setImpactReportDownloadingId] = useState(null);
 
   const sortByParam = searchParams.get('sortBy');
 
@@ -218,6 +265,61 @@ const Taxonomy = () => {
     getDependencyDetails({ ids: id, calendarId })
       .unwrap()
       .then((res) => {
+        const handleImpactedEntitiesDownload = async () => {
+          if (impactReportDownloadingId === id) {
+            return;
+          }
+
+          setImpactReportDownloadingId(id);
+
+          try {
+            const response = await getEntityReverseLinksReport({ ids: [id], calendarId }).unwrap();
+            const reportBlob = response?.blob;
+
+            if (!reportBlob || reportBlob.size === 0) {
+              notification.info({
+                description: t('dashboard.taxonomy.listing.modal.contentDelete.noImpactedEntitiesFound'),
+                placement: 'top',
+                closeIcon: <></>,
+                maxCount: 1,
+                duration: 3,
+              });
+              return;
+            }
+
+            const reportText = await readBlobAsText(reportBlob);
+            if (!reportText.trim()) {
+              notification.info({
+                description: t('dashboard.taxonomy.listing.modal.contentDelete.noImpactedEntitiesFound'),
+                placement: 'top',
+                closeIcon: <></>,
+                maxCount: 1,
+                duration: 3,
+              });
+              return;
+            }
+
+            const filename = parseContentDispositionFilename(
+              response?.contentDisposition,
+              'impacted-entities_report.csv',
+            );
+            downloadBlob({ blob: reportBlob, filename });
+          } catch (error) {
+            notification.error({
+              description:
+                error?.data ||
+                error?.message ||
+                t('dashboard.taxonomy.listing.modal.contentDelete.reportDownloadError'),
+              placement: 'top',
+              closeIcon: <></>,
+              maxCount: 1,
+              duration: 3,
+            });
+          } finally {
+            setImpactReportDownloadingId(null);
+          }
+        };
+
         Confirm({
           title: t('dashboard.taxonomy.listing.modal.titleDelete'),
           onAction: () => {
@@ -241,15 +343,31 @@ const Taxonomy = () => {
           },
           okText: t('dashboard.settings.addUser.delete'),
           cancelText: t('dashboard.settings.addUser.cancel'),
-          content: `${t('dashboard.taxonomy.listing.modal.contentDelete.description')} ${t(
-            'dashboard.taxonomy.listing.modal.contentDelete.impact',
-          )}  ${t('dashboard.taxonomy.listing.modal.contentDelete.published', {
-            number: `${res?.events?.publishedEventCount}`,
-          })}, ${t('dashboard.taxonomy.listing.modal.contentDelete.draft', {
-            number: `${res?.events?.draftEventCount}`,
-          })}, ${t('dashboard.taxonomy.listing.modal.contentDelete.inReview', {
-            number: `${res?.events?.pendingEventCount}`,
-          })}.`,
+          className: 'taxonomy-delete-modal-container',
+          content: (
+            <div className="taxonomy-delete-modal-content-wrapper">
+              <p style={{ marginBottom: 0 }}>
+                {`${t('dashboard.taxonomy.listing.modal.contentDelete.description')} ${t(
+                  'dashboard.taxonomy.listing.modal.contentDelete.impact',
+                )} ${t('dashboard.taxonomy.listing.modal.contentDelete.published', {
+                  number: `${res?.events?.publishedEventCount}`,
+                })}, ${t('dashboard.taxonomy.listing.modal.contentDelete.draft', {
+                  number: `${res?.events?.draftEventCount}`,
+                })}, ${t('dashboard.taxonomy.listing.modal.contentDelete.inReview', {
+                  number: `${res?.events?.pendingEventCount}`,
+                })}.`}
+              </p>
+              <div className="taxonomy-delete-modal-bottom-actions">
+                <Outlined
+                  label={t('dashboard.taxonomy.listing.modal.contentDelete.seeImpactedEntities')}
+                  onClick={handleImpactedEntitiesDownload}
+                  loading={impactReportDownloadingId === id}
+                  disabled={impactReportDownloadingId === id}
+                  data-cy="taxonomy-impacted-entities-download-btn"
+                />
+              </div>
+            </div>
+          ),
         });
       });
   };

--- a/src/pages/Dashboard/Taxonomy/Taxonomy.jsx
+++ b/src/pages/Dashboard/Taxonomy/Taxonomy.jsx
@@ -255,23 +255,13 @@ const Taxonomy = () => {
   const deleteTaxonomyHandler = (id) => {
     getDependencyDetails({ ids: id, calendarId })
       .unwrap()
-      .then((res) => {
+      .then(() => {
         let isDownloadingReport = false;
         let confirmInstance;
 
         const getDeleteConfirmContent = () => (
           <div className="taxonomy-delete-modal-content-wrapper">
-            <p style={{ marginBottom: 0 }}>
-              {`${t('dashboard.taxonomy.listing.modal.contentDelete.description')} ${t(
-                'dashboard.taxonomy.listing.modal.contentDelete.impact',
-              )} ${t('dashboard.taxonomy.listing.modal.contentDelete.published', {
-                number: `${res?.events?.publishedEventCount}`,
-              })}, ${t('dashboard.taxonomy.listing.modal.contentDelete.draft', {
-                number: `${res?.events?.draftEventCount}`,
-              })}, ${t('dashboard.taxonomy.listing.modal.contentDelete.inReview', {
-                number: `${res?.events?.pendingEventCount}`,
-              })}.`}
-            </p>
+            <p style={{ marginBottom: 0 }}>{t('dashboard.taxonomy.listing.modal.contentDelete.description')}</p>
             <div className="taxonomy-delete-modal-bottom-actions">
               <Outlined
                 label={t('dashboard.taxonomy.listing.modal.contentDelete.seeImpactedEntities')}

--- a/src/pages/Dashboard/Taxonomy/Taxonomy.jsx
+++ b/src/pages/Dashboard/Taxonomy/Taxonomy.jsx
@@ -42,23 +42,22 @@ import { entitiesClass, REPORT_ACTION_KEY } from '../../../constants/entitiesCla
 
 const { useBreakpoint } = Grid;
 
-const parseContentDispositionFilename = (contentDisposition, fallback = 'impacted-entities_report.csv') => {
-  if (!contentDisposition) return fallback;
+const slugifyForFilename = (value) => {
+  return (value || '')
+    .toString()
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+};
 
-  const filenameStarMatch = contentDisposition.match(/filename\*=([^;]+)/i);
-  if (filenameStarMatch?.[1]) {
-    const rawValue = filenameStarMatch[1].trim();
-    const encodedFileName = rawValue.includes("''") ? rawValue.split("''").slice(1).join("''") : rawValue;
-    try {
-      const decoded = decodeURIComponent(encodedFileName.replace(/^"|"$/g, ''));
-      return decoded || fallback;
-    } catch (_error) {
-      // Fallback to plain filename parsing.
-    }
-  }
-
-  const filenameMatch = contentDisposition.match(/filename="?([^";]+)"?/i);
-  return filenameMatch?.[1] || fallback;
+const buildTaxonomyImpactedEntitiesFilename = (taxonomyName) => {
+  const slug = slugifyForFilename(taxonomyName) || 'taxonomy';
+  const date = new Date().toISOString().slice(0, 10);
+  return `${slug}-impacted-entities-${date}.csv`;
 };
 
 const downloadBlob = ({ blob, filename }) => {
@@ -252,7 +251,7 @@ const Taxonomy = () => {
       !isReadOnly &&
       navigate(`${PathName.Dashboard}/${calendarId}${PathName.Taxonomies}${PathName.AddTaxonomy}?id=${id}`);
   };
-  const deleteTaxonomyHandler = (id) => {
+  const deleteTaxonomyHandler = (id, taxonomyName) => {
     getDependencyDetails({ ids: id, calendarId })
       .unwrap()
       .then(() => {
@@ -303,10 +302,7 @@ const Taxonomy = () => {
               return;
             }
 
-            const filename = parseContentDispositionFilename(
-              response?.contentDisposition,
-              'impacted-entities_report.csv',
-            );
+            const filename = buildTaxonomyImpactedEntitiesFilename(taxonomyName);
             downloadBlob({ blob: reportBlob, filename });
           } catch (error) {
             notification.error({
@@ -607,7 +603,14 @@ const Taxonomy = () => {
                                   style={{ color: '#222732', fontSize: '24px' }}
                                   onClick={(e) => {
                                     e.stopPropagation();
-                                    deleteTaxonomyHandler(item?.id);
+                                    deleteTaxonomyHandler(
+                                      item?.id,
+                                      contentLanguageBilingual({
+                                        data: item?.name,
+                                        interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
+                                        calendarContentLanguage: calendarContentLanguage,
+                                      }),
+                                    );
                                   }}
                                 />
                               ),

--- a/src/services/entities.js
+++ b/src/services/entities.js
@@ -41,6 +41,49 @@ export const entitiesApi = createApi({
       }),
       transformResponse: (response) => response,
     }),
+    getEntityReverseLinksReport: builder.query({
+      query: ({ ids = [], calendarId }) => {
+        const defaultMessage = 'Failed to download impacted entities report.';
+        const idsArray = Array.isArray(ids) ? ids : [ids];
+        const searchParams = new URLSearchParams();
+
+        idsArray.forEach((entityId) => {
+          if (entityId) {
+            searchParams.append('entity-ids', entityId);
+          }
+        });
+
+        return {
+          url: `entities/reverse-links/report?${searchParams.toString()}`,
+          method: 'GET',
+          headers: {
+            'calendar-id': calendarId,
+          },
+          responseHandler: async (response) => {
+            const blob = await response.blob();
+
+            if (!response.ok) {
+              const errorText = await blob.text();
+              throw new Error(errorText || response.statusText || defaultMessage);
+            }
+
+            return {
+              blob,
+              contentDisposition: response.headers.get('content-disposition'),
+            };
+          },
+        };
+      },
+      transformResponse: (response) => response,
+      transformErrorResponse: (response) => {
+        const defaultMessage = 'Failed to download impacted entities report.';
+
+        return {
+          ...response,
+          data: typeof response?.error === 'string' ? response.error : response?.data || defaultMessage,
+        };
+      },
+    }),
     getEntitiesById: builder.query({
       query: ({ ids, calendarId }) => ({
         url: `entities/ids?${ids}`,
@@ -64,4 +107,5 @@ export const {
   useGetEntitiesByIdQuery,
   useLazyGetEntityDependencyCountQuery,
   useLazyGetEntityDependencyDetailsQuery,
+  useLazyGetEntityReverseLinksReportQuery,
 } = entitiesApi;

--- a/src/services/entities.js
+++ b/src/services/entities.js
@@ -53,8 +53,10 @@ export const entitiesApi = createApi({
           }
         });
 
+        const queryString = searchParams.toString();
+
         return {
-          url: `entities/reverse-links/report?${searchParams.toString()}`,
+          url: `entities/reverse-links/report${queryString ? `?${queryString}` : ''}`,
           method: 'GET',
           headers: {
             'calendar-id': calendarId,


### PR DESCRIPTION
This pull request adds the ability to download a report of impacted entities when deleting a taxonomy, enhancing both the UI and backend integration. It introduces a new button in the taxonomy deletion confirmation modal, updates related styles, and provides new translations for user messages. The backend API is extended to support fetching the impacted entities report as a downloadable CSV file.

**Feature: Impacted Entities Report on Taxonomy Deletion**

- Added a "See impacted entities" button to the taxonomy delete confirmation modal, allowing users to download a CSV report of entities affected by the taxonomy deletion. Handles loading state, error, and "no entities found" cases with user notifications. (`src/pages/Dashboard/Taxonomy/Taxonomy.jsx`, `src/components/Button/Outlined/Outlined`, `src/components/Modal/Confirm/Confirm.jsx`) [[1]](diffhunk://#diff-cf9f0852ed302a42b7a8361e6cd2faecec657653d0140036a1272b4186fd7f0dL217-R321) [[2]](diffhunk://#diff-cf9f0852ed302a42b7a8361e6cd2faecec657653d0140036a1272b4186fd7f0dL514-R613) [[3]](diffhunk://#diff-50a399c5e2e8c33e1746f67dac11f42d106cd5ceb1df0d6536dfdce7bd7928e7L23-R24)
- Added helper functions for filename generation and blob downloading for the report. (`src/pages/Dashboard/Taxonomy/Taxonomy.jsx`)

**Backend Integration**

- Added a new API endpoint and hook `getEntityReverseLinksReport` to fetch the impacted entities report as a blob, including error handling and response transformation. (`src/services/entities.js`) [[1]](diffhunk://#diff-ef13bd5e12f61b588e37724c42818f35f4668c9b53f731931348090d29c0ad84R44-R88) [[2]](diffhunk://#diff-ef13bd5e12f61b588e37724c42818f35f4668c9b53f731931348090d29c0ad84R112)

**UI/UX Improvements**

- Updated the confirmation modal to support both string and React node content, allowing for richer modal content. (`src/components/Modal/Confirm/Confirm.jsx`) [[1]](diffhunk://#diff-50a399c5e2e8c33e1746f67dac11f42d106cd5ceb1df0d6536dfdce7bd7928e7R7) [[2]](diffhunk://#diff-50a399c5e2e8c33e1746f67dac11f42d106cd5ceb1df0d6536dfdce7bd7928e7L23-R24)
- Refined and extended CSS for the confirmation modal, including responsive styles and new classes for the delete modal actions and content. (`src/components/Modal/Confirm/confirm.css`) [[1]](diffhunk://#diff-f783bd1bb4b1e9ab386672d3a553b7931f99baf915f9547230c7f80ea6c8c92fR13) [[2]](diffhunk://#diff-f783bd1bb4b1e9ab386672d3a553b7931f99baf915f9547230c7f80ea6c8c92fR47-R58) [[3]](diffhunk://#diff-f783bd1bb4b1e9ab386672d3a553b7931f99baf915f9547230c7f80ea6c8c92fR104-R150)

**Localization**

- Added English and French translations for new impacted entities report messages and button labels. (`src/locales/en/translationEn.json`, `src/locales/fr/transalationFr.json`) [[1]](diffhunk://#diff-9644cb3f1dd2ea5d5f45429e4c0720538103d1e7205747c4a927acb2319c40d6L1260-R1263) [[2]](diffhunk://#diff-ddff97fe3d9dd6500baa883d1b389bbc5718135aa640f38563df64a52b8a4389L1256-R1259)