### PR TITLE
chore(i18n): rename user management calendar labels

### DIFF
--- a/src/locales/en/translationEn.json
+++ b/src/locales/en/translationEn.json
@@ -975,7 +975,7 @@
         "userType": "User type",
         "languagePreference": "Langage preference",
         "memberOf": "Member of",
-        "calendarAccess": "Calendar access",
+        "calendarAccess": "Member of",
         "details": "Details",
         "breadcrumb": "Back to user list"
       },
@@ -1017,7 +1017,7 @@
         "organizationSearchHeading": "Organization",
         "organizationSearchDescription": "Add organization that will be linked to this user profile.",
         "changePassWord": "Change Password",
-        "calendars": "Calendars",
+        "calendars": "Listings",
         "calendarsDescription": "Select available calendar for this user to join.",
         "calendarSearchHeading": "Calendar access",
         "searchCalendars": "Search calendars",

--- a/src/locales/fr/transalationFr.json
+++ b/src/locales/fr/transalationFr.json
@@ -970,7 +970,7 @@
         "email": "Courriel",
         "userType": "Type d’utilisateur",
         "languagePreference": "Préférence de langue",
-        "calendarAccess": "Accès aux calendriers",
+        "calendarAccess": "Membre de",
         "details": "Détails",
         "breadcrumb": "Retour à la liste des utilisateurs"
       },
@@ -1012,7 +1012,7 @@
         "organizationSearchHeading": "Organisation",
         "organizationSearchDescription": "Ajouter une organisation qui sera liée à ce profil d’utilisateur.",
         "changePassWord": "Changer le mot de passe",
-        "calendars": "Calendriers",
+        "calendars": "Les listages",
         "calendarsDescription": "Sélectionnez des calendriers disponibles auxquels cet utilisateur peut se joindre.",
         "calendarSearchHeading": "Accès aux calendriers",
         "searchCalendars": "Rechercher des calendriers",


### PR DESCRIPTION
This pull request updates the English and French translation files to improve consistency in terminology related to calendar and membership features. The most important changes are grouped below by language.

**English localization changes:**

* Changed the `calendarAccess` label from "Calendar access" to "Member of" to align with membership terminology.
* Changed the `calendars` label from "Calendars" to "Listings" for improved clarity.

**French localization changes:**

* Changed the `calendarAccess` label from "Accès aux calendriers" to "Membre de" to match the updated English term.
* Changed the `calendars` label from "Calendriers" to "Les listages" for consistency with the English translation.