### PR TITLE
Rename user management calendar labels and listings

### DIFF
--- a/src/locales/en/translationEn.json
+++ b/src/locales/en/translationEn.json
@@ -1017,7 +1017,7 @@
         "organizationSearchHeading": "Organization",
         "organizationSearchDescription": "Add organization that will be linked to this user profile.",
         "changePassWord": "Change Password",
-        "calendars": "Listings",
+        "calendars": "Member of",
         "calendarsDescription": "Select available calendar for this user to join.",
         "calendarSearchHeading": "Calendar access",
         "searchCalendars": "Search calendars",

--- a/src/locales/en/translationEn.json
+++ b/src/locales/en/translationEn.json
@@ -975,7 +975,7 @@
         "userType": "User type",
         "languagePreference": "Langage preference",
         "memberOf": "Member of",
-        "calendarAccess": "Calendar access",
+        "calendarAccess": "Member of",
         "details": "Details",
         "breadcrumb": "Back to user list"
       },
@@ -1017,7 +1017,7 @@
         "organizationSearchHeading": "Organization",
         "organizationSearchDescription": "Add organization that will be linked to this user profile.",
         "changePassWord": "Change Password",
-        "calendars": "Calendars",
+        "calendars": "Listings",
         "calendarsDescription": "Select available calendar for this user to join.",
         "calendarSearchHeading": "Calendar access",
         "searchCalendars": "Search calendars",

--- a/src/locales/fr/transalationFr.json
+++ b/src/locales/fr/transalationFr.json
@@ -970,7 +970,7 @@
         "email": "Courriel",
         "userType": "Type d’utilisateur",
         "languagePreference": "Préférence de langue",
-        "calendarAccess": "Accès aux calendriers",
+        "calendarAccess": "Membre de",
         "details": "Détails",
         "breadcrumb": "Retour à la liste des utilisateurs"
       },
@@ -1012,7 +1012,7 @@
         "organizationSearchHeading": "Organisation",
         "organizationSearchDescription": "Ajouter une organisation qui sera liée à ce profil d’utilisateur.",
         "changePassWord": "Changer le mot de passe",
-        "calendars": "Calendriers",
+        "calendars": "Les listages",
         "calendarsDescription": "Sélectionnez des calendriers disponibles auxquels cet utilisateur peut se joindre.",
         "calendarSearchHeading": "Accès aux calendriers",
         "searchCalendars": "Rechercher des calendriers",

--- a/src/locales/fr/transalationFr.json
+++ b/src/locales/fr/transalationFr.json
@@ -1012,7 +1012,7 @@
         "organizationSearchHeading": "Organisation",
         "organizationSearchDescription": "Ajouter une organisation qui sera liée à ce profil d’utilisateur.",
         "changePassWord": "Changer le mot de passe",
-        "calendars": "Les listages",
+        "calendars": "Membre de",
         "calendarsDescription": "Sélectionnez des calendriers disponibles auxquels cet utilisateur peut se joindre.",
         "calendarSearchHeading": "Accès aux calendriers",
         "searchCalendars": "Rechercher des calendriers",


### PR DESCRIPTION
This pull request updates the English and French localization files to standardize the labels for calendar-related fields, changing them from "Calendar access" and "Calendars" to "Member of" for consistency across the user interface.

Localization updates:

* In `translationEn.json`, the `calendarAccess` and `calendars` fields are now labeled as "Member of" instead of "Calendar access" or "Calendars" to unify terminology. [[1]](diffhunk://#diff-9644cb3f1dd2ea5d5f45429e4c0720538103d1e7205747c4a927acb2319c40d6L978-R978) [[2]](diffhunk://#diff-9644cb3f1dd2ea5d5f45429e4c0720538103d1e7205747c4a927acb2319c40d6L1020-R1020)
* In `transalationFr.json`, the `calendarAccess` and `calendars` fields are now labeled as "Membre de" instead of "Accès aux calendriers" or "Calendriers" to match the English changes and ensure consistency. [[1]](diffhunk://#diff-ddff97fe3d9dd6500baa883d1b389bbc5718135aa640f38563df64a52b8a4389L973-R973) [[2]](diffhunk://#diff-ddff97fe3d9dd6500baa883d1b389bbc5718135aa640f38563df64a52b8a4389L1015-R1015)