### PR TITLE
Fix action button positioning and add read-only headers in settings

### DIFF
--- a/src/components/Sidebar/Responsive/ResponsiveSidebar.jsx
+++ b/src/components/Sidebar/Responsive/ResponsiveSidebar.jsx
@@ -71,27 +71,16 @@ function ResponsiveSidebar(props) {
           />
         ),
         label: (
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-            }}>
-            <span style={{ height: currentCalendarData?.mode === calendarModes.READ_ONLY && '16px' }}>
-              {label}
-              <DownOutlined
-                style={{
-                  position: 'relative',
-                  left: '70%',
-                  top: '50%',
-                  fontSize: '8px',
-                }}
-              />
+          <div className="calendar-label-wrapper">
+            <span
+              className="calendar-label-row"
+              style={{ height: currentCalendarData?.mode === calendarModes.READ_ONLY ? '16px' : undefined }}>
+              <span className="calendar-label-text">{label}</span>
+              <DownOutlined className="calendar-label-icon" />
             </span>
 
             {currentCalendarData?.mode === calendarModes.READ_ONLY && (
-              <span style={{ fontSize: '12px', fontWeight: 400 }}>
-                {t('dashboard.calendar.readOnlyMode.readOnlyMode')}
-              </span>
+              <span className="calendar-read-only-label">{t('dashboard.calendar.readOnlyMode.readOnlyMode')}</span>
             )}
           </div>
         ),

--- a/src/components/Sidebar/Responsive/responsiveSidebar.css
+++ b/src/components/Sidebar/Responsive/responsiveSidebar.css
@@ -18,7 +18,8 @@
 
 .sidebar-navigation-menu-responsive-drawer .sidebar-calendar {
   gap: 8px;
-  height: 48px;
+  height: auto;
+  min-height: 48px;
   background: rgba(255, 255, 255, 0.005);
   font-weight: 700;
   font-size: 12px;
@@ -28,6 +29,7 @@
   display: flex;
   align-items: center;
   padding: 8px;
+  overflow: hidden;
 }
 
 .sidebar-navigation-menu-responsive-drawer .sidebar-calendar .ant-menu-title-content {
@@ -35,14 +37,68 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  gap: 8px;
 }
 
 .sidebar-navigation-menu-responsive-drawer .ant-drawer-extra {
   margin-left: 17px;
+  flex-shrink: 0;
 }
 
 .sidebar-navigation-menu-responsive-drawer .ant-drawer-header {
   border-bottom: none;
+  gap: 12px;
+}
+
+.sidebar-navigation-menu-responsive-drawer .ant-drawer-header-title,
+.sidebar-navigation-menu-responsive-drawer .ant-drawer-title,
+.sidebar-navigation-menu-responsive-drawer .sidebar-calendar-menu-responsive {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.sidebar-navigation-menu-responsive-drawer .sidebar-calendar-menu-responsive .ant-menu {
+  width: 100%;
+  min-width: 0;
+}
+
+/* Calendar label - wrapping fix for long names to avoid overlap with close button */
+.sidebar-navigation-menu-responsive-drawer .calendar-label-wrapper {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+}
+
+.sidebar-navigation-menu-responsive-drawer .calendar-label-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.sidebar-navigation-menu-responsive-drawer .calendar-label-text {
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  line-height: 1.3;
+}
+
+.sidebar-navigation-menu-responsive-drawer .calendar-label-icon {
+  font-size: 8px;
+  flex-shrink: 0;
+}
+
+.sidebar-navigation-menu-responsive-drawer .calendar-read-only-label {
+  font-size: 12px;
+  font-weight: 400;
 }
 
 .sidebar-navigation-menu-responsive-drawer .ant-drawer-footer {

--- a/src/pages/Dashboard/PlaceReadOnly/PlaceReadOnly.jsx
+++ b/src/pages/Dashboard/PlaceReadOnly/PlaceReadOnly.jsx
@@ -319,8 +319,8 @@ function PlaceReadOnly() {
       <Row gutter={[32, 24]} className="read-only-wrapper place-read-only" style={{ margin: 0 }}>
         <div className="place-read-only-sticky-header" ref={stickyHeaderRef}>
           <Col className="top-level-column" span={24}>
-            <Row>
-              <Col flex="auto">
+            <Row wrap={false}>
+              <Col flex="auto" className="place-read-only-breadcrumb-col">
                 <Breadcrumbs
                   name={contentLanguageBilingual({
                     data: placeData?.name,

--- a/src/pages/Dashboard/PlaceReadOnly/placeReadOnly.css
+++ b/src/pages/Dashboard/PlaceReadOnly/placeReadOnly.css
@@ -32,6 +32,18 @@
   padding: 0px !important;
 }
 
+.place-read-only .place-read-only-breadcrumb-col {
+  min-width: 0;
+  padding-right: 16px;
+}
+
+.place-read-only .place-read-only-breadcrumb-col .breadcrumbs,
+.place-read-only .place-read-only-breadcrumb-col .breadcrumb-item {
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .place-read-only .read-only-detail-heading {
   font-size: 24px;
 }

--- a/src/pages/Dashboard/Settings/CalendarSettings/CalendarSettings.jsx
+++ b/src/pages/Dashboard/Settings/CalendarSettings/CalendarSettings.jsx
@@ -327,21 +327,17 @@ function CalendarSettings({ setDirtyStatus, tabKey }) {
   return !debouncedLoading ? (
     <div>
       <Row className="calendar-settings-wrapper" gutter={[0, 18]}>
-        <Col span={24} className="calendar-settings-save-col">
-          <Row justify={'space-between'} align={'middle'}>
-            <Col>
-              <h5 className="calendar-settings-heading" data-cy="heading5-calendar-settings">
-                {t('dashboard.settings.calendarSettings.generalSettings')}
-              </h5>
-            </Col>
-            <Col>
-              <PrimaryButton
-                label={t('dashboard.events.addEditEvent.saveOptions.save')}
-                data-cy="button-save-calendar-settings"
-                onClick={onSaveHandler}
-              />
-            </Col>
-          </Row>
+        <Col flex="auto" className="calendar-settings-heading-col">
+          <h5 className="calendar-settings-heading" data-cy="heading5-calendar-settings">
+            {t('dashboard.settings.calendarSettings.generalSettings')}
+          </h5>
+        </Col>
+        <Col flex="none" className="calendar-settings-save-col">
+          <PrimaryButton
+            label={t('dashboard.events.addEditEvent.saveOptions.save')}
+            data-cy="button-save-calendar-settings"
+            onClick={onSaveHandler}
+          />
         </Col>
         <Col span={24}>
           <p className="calendar-settings-description" data-cy="para-calendar-settings-description">

--- a/src/pages/Dashboard/Settings/CalendarSettings/CalendarSettings.jsx
+++ b/src/pages/Dashboard/Settings/CalendarSettings/CalendarSettings.jsx
@@ -43,6 +43,36 @@ function CalendarSettings({ setDirtyStatus, tabKey }) {
   const [updateCalendar, { isLoading: updateCalendarLoading }] = useUpdateCalendarMutation();
   const [addImage, { isLoading: addImageLoading }] = useAddImageMutation();
   const [debouncedLoading, setDebouncedLoading] = useState(true);
+  const [activeHeadingKey, setActiveHeadingKey] = useState('dashboard.settings.calendarSettings.generalSettings');
+
+  useEffect(() => {
+    let frameId;
+    const handleScroll = () => {
+      if (frameId) cancelAnimationFrame(frameId);
+      frameId = requestAnimationFrame(() => {
+        const widgetHeading = document.getElementById('widget-settings-section');
+        const filterHeading = document.getElementById('filter-settings-section');
+        const saveCol = document.querySelector('.calendar-settings-save-col');
+
+        const threshold = saveCol ? saveCol.getBoundingClientRect().bottom + 40 : 200;
+
+        if (filterHeading && filterHeading.getBoundingClientRect().top <= threshold) {
+          setActiveHeadingKey('dashboard.settings.calendarSettings.filterPersonalization');
+        } else if (widgetHeading && widgetHeading.getBoundingClientRect().top <= threshold) {
+          setActiveHeadingKey('dashboard.settings.calendarSettings.calendarWidgetSetup');
+        } else {
+          setActiveHeadingKey('dashboard.settings.calendarSettings.generalSettings');
+        }
+      });
+    };
+
+    window.addEventListener('scroll', handleScroll, true);
+    handleScroll();
+    return () => {
+      window.removeEventListener('scroll', handleScroll, true);
+      if (frameId) cancelAnimationFrame(frameId);
+    };
+  }, []);
 
   const isAnyLoading = useMemo(
     () =>
@@ -327,17 +357,21 @@ function CalendarSettings({ setDirtyStatus, tabKey }) {
   return !debouncedLoading ? (
     <div>
       <Row className="calendar-settings-wrapper" gutter={[0, 18]}>
-        <Col flex="auto" className="calendar-settings-heading-col">
-          <h5 className="calendar-settings-heading" data-cy="heading5-calendar-settings">
-            {t('dashboard.settings.calendarSettings.generalSettings')}
-          </h5>
-        </Col>
-        <Col flex="none" className="calendar-settings-save-col">
-          <PrimaryButton
-            label={t('dashboard.events.addEditEvent.saveOptions.save')}
-            data-cy="button-save-calendar-settings"
-            onClick={onSaveHandler}
-          />
+        <Col span={24} className="calendar-settings-save-col">
+          <Row justify={'space-between'} align={'middle'}>
+            <Col style={{ flex: 1, minWidth: 0, marginRight: '16px' }}>
+              <h5 className="calendar-settings-heading" data-cy="heading5-calendar-settings" style={{ margin: 0 }}>
+                {t(activeHeadingKey)}
+              </h5>
+            </Col>
+            <Col style={{ flexShrink: 0 }}>
+              <PrimaryButton
+                label={t('dashboard.events.addEditEvent.saveOptions.save')}
+                data-cy="button-save-calendar-settings"
+                onClick={onSaveHandler}
+              />
+            </Col>
+          </Row>
         </Col>
         <Col span={24}>
           <p className="calendar-settings-description" data-cy="para-calendar-settings-description">
@@ -384,7 +418,10 @@ function CalendarSettings({ setDirtyStatus, tabKey }) {
               );
             })}
             <Divider />
-            <h5 className="calendar-settings-heading calendar-settings-section-heading" style={{ paddingTop: '24px' }}>
+            <h5
+              id="widget-settings-section"
+              className="calendar-settings-heading calendar-settings-section-heading"
+              style={{ paddingTop: '24px' }}>
               {t('dashboard.settings.calendarSettings.calendarWidgetSetup')}
             </h5>
             <p className="calendar-settings-description">
@@ -404,7 +441,10 @@ function CalendarSettings({ setDirtyStatus, tabKey }) {
               );
             })}
             <Divider />
-            <h5 className="calendar-settings-heading calendar-settings-section-heading" style={{ paddingTop: '24px' }}>
+            <h5
+              id="filter-settings-section"
+              className="calendar-settings-heading calendar-settings-section-heading"
+              style={{ paddingTop: '24px' }}>
               {t('dashboard.settings.calendarSettings.filterPersonalization')}
             </h5>
             <p className="calendar-settings-description">

--- a/src/pages/Dashboard/Settings/CalendarSettings/calendarSettings.css
+++ b/src/pages/Dashboard/Settings/CalendarSettings/calendarSettings.css
@@ -94,6 +94,17 @@
   padding-bottom: 8px;
 }
 
+.calendar-settings-wrapper .calendar-settings-heading-col {
+  position: sticky;
+  top: 160px;
+  z-index: 9;
+  background: #fff;
+  padding-top: 24px;
+  padding-bottom: 8px;
+  display: flex;
+  align-items: center;
+}
+
 .calendar-settings-wrapper .calendar-settings-section-heading {
   position: sticky;
   top: 160px;
@@ -107,9 +118,21 @@
   .calendar-settings-wrapper .calendar-settings-save-col {
     top: 128px;
     padding-top: 40px;
+    padding-bottom: 0;
+    background: transparent;
+  }
+  .calendar-settings-wrapper .calendar-settings-heading-col {
+    position: static;
+    padding-top: 40px;
   }
   .calendar-settings-wrapper .calendar-settings-section-heading {
     position: static;
+  }
+}
+
+@media (max-width: 480px) {
+  .calendar-settings-wrapper .calendar-settings-save-col {
+    top: 130px;
   }
 }
 

--- a/src/pages/Dashboard/Settings/CalendarSettings/calendarSettings.css
+++ b/src/pages/Dashboard/Settings/CalendarSettings/calendarSettings.css
@@ -3,6 +3,8 @@
   font-weight: 700;
   line-height: 32px;
   color: #222732;
+  white-space: normal;
+  overflow-wrap: break-word;
 }
 
 .calendar-settings-wrapper .calendar-settings-title {
@@ -94,45 +96,17 @@
   padding-bottom: 8px;
 }
 
-.calendar-settings-wrapper .calendar-settings-heading-col {
-  position: sticky;
-  top: 160px;
-  z-index: 9;
-  background: #fff;
-  padding-top: 24px;
-  padding-bottom: 8px;
-  display: flex;
-  align-items: center;
-}
-
 .calendar-settings-wrapper .calendar-settings-section-heading {
-  position: sticky;
-  top: 160px;
-  z-index: 9;
-  background: #fff;
   padding-bottom: 8px;
   width: 100%;
+  white-space: normal;
+  overflow-wrap: break-word;
 }
 
 @media (max-width: 767px) {
   .calendar-settings-wrapper .calendar-settings-save-col {
     top: 128px;
     padding-top: 40px;
-    padding-bottom: 0;
-    background: transparent;
-  }
-  .calendar-settings-wrapper .calendar-settings-heading-col {
-    position: static;
-    padding-top: 40px;
-  }
-  .calendar-settings-wrapper .calendar-settings-section-heading {
-    position: static;
-  }
-}
-
-@media (max-width: 480px) {
-  .calendar-settings-wrapper .calendar-settings-save-col {
-    top: 130px;
   }
 }
 


### PR DESCRIPTION
This pull request introduces UI improvements to the `PlaceReadOnly` and `CalendarSettings` dashboard pages, focusing on layout adjustments and enhanced responsiveness for better readability and usability across different screen sizes. The main changes include restructuring layout components, refining sticky header behavior, and updating CSS for improved text handling and mobile support.

**Layout and Styling Improvements:**

* `PlaceReadOnly.jsx` and `placeReadOnly.css`:
  - Adjusted the breadcrumb column to prevent overflow and ensure proper wrapping of long text, enhancing readability on smaller screens. [[1]](diffhunk://#diff-c24ea32e1a40dd241c1a7b03f5dd557344450f6c2bf80c867feb314bc400bbb6L322-R323) [[2]](diffhunk://#diff-ab0488d7b7e599908505882e6f3ac2cde93c02f41388f54d36222763089e4f58R35-R46)

* `CalendarSettings.jsx` and `calendarSettings.css`:
  - Refactored the heading and save button layout for better alignment and stickiness, ensuring the heading remains visible while scrolling. [[1]](diffhunk://#diff-3788d9be9811de17fab4d192a3b730274f29bead154e1640c3e1bc7e3b57665aL330-L345) [[2]](diffhunk://#diff-9afc48e0ace540a1183f15f639af60126f26c9aaf74e8686daf3e34113bd968dR97-R107)
  - Improved responsiveness and sticky positioning for the heading and save button, including specific tweaks for tablet and mobile breakpoints. [[1]](diffhunk://#diff-9afc48e0ace540a1183f15f639af60126f26c9aaf74e8686daf3e34113bd968dR121-R126) [[2]](diffhunk://#diff-9afc48e0ace540a1183f15f639af60126f26c9aaf74e8686daf3e34113bd968dR139-R144)