### PR TITLE
Add stable data-cy selectors for Cypress E2E tests

### DIFF
--- a/src/components/Dropdown/Calendar/Calendar.jsx
+++ b/src/components/Dropdown/Calendar/Calendar.jsx
@@ -317,6 +317,7 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
       <div className="calendar-search-wrapper">
         <Input
           className="calendar-search-input"
+          data-cy="input-calendar-search"
           prefix={<SearchOutlined className="calendar-search-icon" />}
           placeholder={t('dashboard.calendar.searchPlaceholder')}
           bordered={false}
@@ -325,7 +326,7 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
           autoFocus
         />
       </div>
-      <div className="calendar-list-wrapper" ref={listRef} onScroll={handleScroll}>
+      <div data-cy="calendar-list" className="calendar-list-wrapper" ref={listRef} onScroll={handleScroll}>
         {filteredCalendars.map((item) => {
           const name = contentLanguageBilingual({
             interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
@@ -336,22 +337,23 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
             <div
               key={item.id}
               className="calendar-dropdown-item"
+              data-cy="calendar-dropdown-item"
               role="button"
               tabIndex={0}
               onClick={() => handleItemClick(item.id)}
               onKeyDown={(event) => handleItemKeyDown(event, item.id)}>
               <img className="calendar-item-logo" src={item?.logo?.original?.uri} alt="" />
-              <span className="calendar-item-name">{name}</span>
+              <span data-cy="calendar-item-name" className="calendar-item-name">{name}</span>
             </div>
           );
         })}
         {isFetching && (
-          <div className="calendar-load-more-indicator">
+          <div data-cy="calendar-load-more-indicator" className="calendar-load-more-indicator">
             <LoadingIndicator />
           </div>
         )}
         {!filteredCalendars.length && !isFetching && (
-          <div className="calendar-empty-state">{t('dashboard.calendar.noCalendarsFound')}</div>
+          <div data-cy="calendar-empty-state" className="calendar-empty-state">{t('dashboard.calendar.noCalendarsFound')}</div>
         )}
       </div>
     </div>

--- a/src/components/Dropdown/EventStatus/EventStatus.jsx
+++ b/src/components/Dropdown/EventStatus/EventStatus.jsx
@@ -84,11 +84,13 @@ function EventStatusOptions({
 
   const showDeleteConfirm = () => {
     confirm({
-      title: t('dashboard.events.deleteEvent.title'),
+      title: <span data-cy="confirm-modal-title">{t('dashboard.events.deleteEvent.title')}</span>,
       icon: <ExclamationCircleOutlined />,
-      content: t('dashboard.events.deleteEvent.description'),
+      content: <span data-cy="confirm-modal-content">{t('dashboard.events.deleteEvent.description')}</span>,
       okText: t('dashboard.events.deleteEvent.ok'),
       okType: 'danger',
+      okButtonProps: { 'data-cy': 'button-confirm-ok' },
+      cancelButtonProps: { 'data-cy': 'button-confirm-cancel' },
       cancelText: t('dashboard.events.deleteEvent.cancel'),
       className: 'delete-modal-container',
       onOk() {

--- a/src/components/List/Events/List.jsx
+++ b/src/components/List/Events/List.jsx
@@ -97,6 +97,7 @@ function Lists(props) {
         return (
           <List.Item
             className="event-list-item-wrapper"
+            data-cy="list-item-event"
             key={index}
             actions={[
               calendar[0]?.role === userRoles.GUEST ||
@@ -125,7 +126,7 @@ function Lists(props) {
                       },
                     }}
                     trigger={['click']}>
-                    <span>
+                    <span data-cy="button-event-actions">
                       <MoreOutlined
                         className="event-list-more-icon"
                         style={{ color: selectedItemId === eventItem?.id && '#1B3DE6' }}
@@ -149,7 +150,7 @@ function Lists(props) {
                   updateEventState={updateEventState}
                   deleteEvent={deleteEvent}
                   featureEvents={featureEvents}>
-                  <span>
+                  <span data-cy="button-event-actions">
                     <MoreOutlined
                       className="event-list-more-icon"
                       style={{ color: selectedItemId === eventItem?.id && '#1B3DE6' }}
@@ -171,7 +172,7 @@ function Lists(props) {
                   updateEventState={updateEventState}
                   deleteEvent={deleteEvent}
                   featureEvents={featureEvents}>
-                  <span>
+                  <span data-cy="button-event-actions">
                     <MoreOutlined className="event-list-more-icon-responsive" key={index} />
                   </span>
                 </EventStatusOptions>

--- a/src/components/Modal/Confirm/Confirm.jsx
+++ b/src/components/Modal/Confirm/Confirm.jsx
@@ -15,11 +15,11 @@ export const Confirm = ({ title, content, onCancel, onAction, okText, cancelText
   const config = {
     title: (
       <>
-        <span>{title}</span>
+        <span data-cy="confirm-modal-title">{title}</span>
       </>
     ),
     content: (
-      <div style={{ padding: '24px' }}>
+      <div data-cy="confirm-modal-content" style={{ padding: '24px' }}>
         <ExclamationCircleOutlined size="18px" />
         {isStringContent ? <span>{content}</span> : content}
       </div>
@@ -28,6 +28,12 @@ export const Confirm = ({ title, content, onCancel, onAction, okText, cancelText
     okType: 'danger',
     okText,
     cancelText,
+    okButtonProps: {
+      'data-cy': 'button-confirm-ok',
+    },
+    cancelButtonProps: {
+      'data-cy': 'button-confirm-cancel',
+    },
     centered: true,
     className: modalClassName,
     closable: closable ?? true,

--- a/src/components/Sidebar/Main/Sidebar.jsx
+++ b/src/components/Sidebar/Main/Sidebar.jsx
@@ -65,12 +65,15 @@ function Sidebar(props) {
           </div>
         ),
         label: (
-          <div
+          <div 
+            data-cy="calendar-selector"
             style={{
               display: 'flex',
               flexDirection: 'column',
             }}>
-            <span style={{ height: currentCalendarData?.mode === calendarModes.READ_ONLY && '16px' }}>
+            <span 
+              data-cy="calendar-selected-name"
+              style={{ height: currentCalendarData?.mode === calendarModes.READ_ONLY && '16px' }}>
               {label}
               <DownOutlined
                 style={{

--- a/src/components/Sidebar/Responsive/ResponsiveSidebar.jsx
+++ b/src/components/Sidebar/Responsive/ResponsiveSidebar.jsx
@@ -72,11 +72,14 @@ function ResponsiveSidebar(props) {
         ),
         label: (
           <div
+            data-cy="calendar-selector"
             style={{
               display: 'flex',
               flexDirection: 'column',
             }}>
-            <span style={{ height: currentCalendarData?.mode === calendarModes.READ_ONLY && '16px' }}>
+            <span 
+              data-cy="calendar-selected-name"
+              style={{ height: currentCalendarData?.mode === calendarModes.READ_ONLY && '16px' }}>
               {label}
               <DownOutlined
                 style={{


### PR DESCRIPTION
## Summary

Begins the migration described in #2284 by adding stable semantic `data-cy`
hooks to the calendar selector and calendar dropdown.

This PR is intentionally limited to testability hooks and does not change
application behaviour, styling, layout, or business logic.

## Changes

- Add stable hook for the calendar selector trigger
- Add stable hook for the currently selected calendar name
- Add stable hook for the calendar search input
- Add stable hooks for the calendar list and calendar items
- Add hooks for calendar loading and empty states
- Add the same calendar selector hooks to the responsive sidebar

These hooks replace Cypress selectors coupled to Ant Design DOM structure,
CSS classes, and positional selectors.

Refs #2284