### PR TITLE
feat: integration for structured data copy paste

### DIFF
--- a/.env.staging
+++ b/.env.staging
@@ -1,4 +1,5 @@
 VITE_APP_API_URL="https://staging-api-cms.footlight.io"
+VITE_APP_OPEN_API_URL="https://staging-api.footlight.io"
 VITE_APP_ARTS_DATA_URI="https://api.artsdata.ca/"
 VITE_APP_ARTS_DATA_PAGE_URI="https://kg.artsdata.ca/resource/"
 VITE_APP_DEEPL_URL="https://www.deepl.com/translator#"

--- a/src/components/Dropdown/EventStatus/EventStatus.jsx
+++ b/src/components/Dropdown/EventStatus/EventStatus.jsx
@@ -4,7 +4,6 @@ import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { useTranslation } from 'react-i18next';
 import { eventPublishOptions } from '../../../constants/eventPublishOptions';
 import './eventStatus.css';
-import ProtectedComponents from '../../../layout/ProtectedComponents';
 import { eventPublishState } from '../../../constants/eventPublishState';
 import { useNavigate, useOutletContext, useParams } from 'react-router-dom';
 import { PathName } from '../../../constants/pathName';
@@ -23,6 +22,7 @@ function EventStatusOptions({
   updateEventState,
   deleteEvent,
   featureEvents,
+  onGetStructuredData,
   ...rest
 }) {
   const { t } = useTranslation();
@@ -33,7 +33,20 @@ function EventStatusOptions({
   const calendar = getCurrentCalendarDetailsFromUserDetails(user, calendarId);
   const canFeature = [userRoles.ADMIN, userRoles.EDITOR].includes(calendar[0]?.role) || user?.isSuperAdmin;
 
-  const items = eventPublishOptions
+  // Write-action tier, reproducing the previous ProtectedComponents wrapper (super admin bypasses
+  // read-only) plus the duplicate-only dropdown the list rendered for guests and non-creator
+  // contributors. The dropdown itself now always renders so read actions stay available to everyone.
+  const role = calendar[0]?.role;
+  const isOwner = user?.id === creator?.userId;
+  let writeTier; // 'all' | 'duplicateOnly' | 'none'
+  if (user?.isSuperAdmin) writeTier = 'all';
+  else if (isReadOnly) writeTier = 'none';
+  else if (role === userRoles.ADMIN || role === userRoles.EDITOR) writeTier = 'all';
+  else if (role === userRoles.CONTRIBUTOR) writeTier = isOwner ? 'all' : 'duplicateOnly';
+  else if (role === userRoles.GUEST) writeTier = 'duplicateOnly';
+  else writeTier = 'none';
+
+  const publishStateItems = eventPublishOptions
     .filter((item) => canFeature || (item.key !== '4' && item.key !== '5'))
     .map((item) => {
       if (publishState == eventPublishState.PUBLISHED) {
@@ -82,6 +95,17 @@ function EventStatusOptions({
       }
     });
 
+  let writeItems = [];
+  if (writeTier === 'all') writeItems = publishStateItems.filter(Boolean);
+  else if (writeTier === 'duplicateOnly') writeItems = eventPublishOptions.filter((item) => item.key === '3');
+
+  const hasWriteItems = writeItems.some((item) => item?.key);
+
+  const items = [
+    { key: '7', label: t('dashboard.events.publishOptions.copyJsonLd') },
+    ...(hasWriteItems ? [{ type: 'divider', key: 'jsonld-divider' }, ...writeItems] : []),
+  ];
+
   const showDeleteConfirm = () => {
     confirm({
       title: t('dashboard.events.deleteEvent.title'),
@@ -110,7 +134,8 @@ function EventStatusOptions({
     });
   };
   const onClick = ({ key }) => {
-    if (key == '2') showDeleteConfirm();
+    if (key === '7') onGetStructuredData && onGetStructuredData(eventData);
+    else if (key == '2') showDeleteConfirm();
     else if (key === '0' || key === '1' || key === '6') {
       const isPublishing = key === '0';
       const isUnpublishing = key === '1' || key === '6';
@@ -163,23 +188,21 @@ function EventStatusOptions({
     }
   };
   return (
-    <ProtectedComponents creator={creator} isReadOnly={isReadOnly}>
-      <Dropdown
-        {...rest}
-        className="calendar-dropdown-wrapper"
-        overlayClassName="event-dropdown-popup"
-        overlayStyle={{
-          minWidth: '150px',
-        }}
-        getPopupContainer={(trigger) => trigger.parentNode}
-        menu={{
-          items,
-          onClick,
-        }}
-        trigger={['click']}>
-        {children}
-      </Dropdown>
-    </ProtectedComponents>
+    <Dropdown
+      {...rest}
+      className="calendar-dropdown-wrapper"
+      overlayClassName="event-dropdown-popup"
+      overlayStyle={{
+        minWidth: '150px',
+      }}
+      getPopupContainer={(trigger) => trigger.parentNode}
+      menu={{
+        items,
+        onClick,
+      }}
+      trigger={['click']}>
+      {children}
+    </Dropdown>
   );
 }
 

--- a/src/components/List/Events/List.jsx
+++ b/src/components/List/Events/List.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useLocation, useNavigate, useOutletContext, useParams } from 'react-router-dom';
 import './list.css';
-import { List, Grid, Dropdown } from 'antd';
+import { List, Grid } from 'antd';
 import { MoreOutlined, StarOutlined } from '@ant-design/icons';
 import EventStatus from '../../Tags/Events';
 import EventNumber from '../../Tags/EventNumber';
@@ -11,8 +11,8 @@ import { contentLanguageBilingual } from '../../../utils/bilingual';
 import { useSelector } from 'react-redux';
 import { getUserDetails } from '../../../redux/reducer/userSlice';
 import i18n from 'i18next';
-import { PathName } from '../../../constants/pathName';
 import Username from '../../Username/index';
+import StructuredDataModal from '../../StructuredDataModal';
 import { dateTimeTypeHandler } from '../../../utils/dateTimeTypeHandler';
 import { dateTypes } from '../../../constants/dateTypes';
 import { userRoles } from '../../../constants/userRoles';
@@ -36,11 +36,12 @@ function Lists(props) {
   let { calendarId } = useParams();
   const lang = i18n.language;
   const { user } = useSelector(getUserDetails);
-  const [currentCalendarData, , , , , isReadOnly] = useOutletContext();
+  const [currentCalendarData] = useOutletContext();
   const totalCount = data?.totalCount;
   const dateTimeFormat = lang === 'fr' ? 'DD MMM YYYY - HH:mm' : 'DD MMM YYYY - h:mm a';
 
   const [selectedItemId, setSelectedItemId] = useState(null);
+  const [structuredDataEvent, setStructuredDataEvent] = useState(null);
 
   let calendar = user?.roles?.filter((calendar) => {
     return calendar?.calendarId === calendarId;
@@ -67,74 +68,49 @@ function Lists(props) {
   let imageDimensions = calculateImageDimensions(aspectRatioString, 104, 150);
 
   return (
-    <List
-      className="event-list-wrapper"
-      itemLayout={!screens.md ? 'vertical' : 'horizontal'}
-      dataSource={data?.data}
-      bordered={false}
-      pagination={{
-        onChange: (page) => {
-          setPageNumber(page);
-        },
-        pageSize: 10,
-        hideOnSinglePage: true,
-        total: totalCount,
-        current: Number(pageNumber),
-        showSizeChanger: false,
-      }}
-      renderItem={(eventItem, index) => {
-        const hasStartTime = eventItem?.startDateTime?.includes('T') || eventItem?.startDate?.includes(' ');
-        const evenDateType = dateTimeTypeHandler(
-          eventItem?.startDate,
-          eventItem?.startDateTime,
-          eventItem?.endDate,
-          eventItem?.endDateTime,
-          eventItem?.subEventDetails?.totalSubEventCount > 0 ? true : false,
-        );
-        const eventDateFormat = hasStartTime && evenDateType == dateTypes.SINGLE ? dateTimeFormat : 'DD-MMM-YYYY';
-        const scheduleTimezone = eventItem?.scheduleTimezone ?? 'Canada/Eastern';
+    <>
+      <StructuredDataModal
+        visible={!!structuredDataEvent}
+        onCancel={() => setStructuredDataEvent(null)}
+        eventId={structuredDataEvent?.id}
+        eventName={contentLanguageBilingual({
+          data: structuredDataEvent?.name,
+          interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
+          calendarContentLanguage: calendarContentLanguage,
+        })}
+      />
+      <List
+        className="event-list-wrapper"
+        itemLayout={!screens.md ? 'vertical' : 'horizontal'}
+        dataSource={data?.data}
+        bordered={false}
+        pagination={{
+          onChange: (page) => {
+            setPageNumber(page);
+          },
+          pageSize: 10,
+          hideOnSinglePage: true,
+          total: totalCount,
+          current: Number(pageNumber),
+          showSizeChanger: false,
+        }}
+        renderItem={(eventItem, index) => {
+          const hasStartTime = eventItem?.startDateTime?.includes('T') || eventItem?.startDate?.includes(' ');
+          const evenDateType = dateTimeTypeHandler(
+            eventItem?.startDate,
+            eventItem?.startDateTime,
+            eventItem?.endDate,
+            eventItem?.endDateTime,
+            eventItem?.subEventDetails?.totalSubEventCount > 0 ? true : false,
+          );
+          const eventDateFormat = hasStartTime && evenDateType == dateTypes.SINGLE ? dateTimeFormat : 'DD-MMM-YYYY';
+          const scheduleTimezone = eventItem?.scheduleTimezone ?? 'Canada/Eastern';
 
-        return (
-          <List.Item
-            className="event-list-item-wrapper"
-            key={index}
-            actions={[
-              calendar[0]?.role === userRoles.GUEST ||
-              (calendar[0]?.role === userRoles.CONTRIBUTOR && eventItem?.creator?.userId != user?.id) ? (
-                !isReadOnly && (
-                  <Dropdown
-                    className="calendar-dropdown-wrapper"
-                    onOpenChange={(open) => {
-                      if (open) setSelectedItemId(eventItem?.id);
-                      else setSelectedItemId(null);
-                    }}
-                    overlayStyle={{
-                      minWidth: '150px',
-                    }}
-                    getPopupContainer={(trigger) => trigger.parentNode}
-                    menu={{
-                      items: [
-                        {
-                          key: '0',
-                          label: t('dashboard.events.publishOptions.duplicateEvent'),
-                        },
-                      ],
-                      onClick: ({ key }) => {
-                        if (key === '0')
-                          navigate(`${location.pathname}${PathName.AddEvent}?duplicateId=${eventItem?.id}`);
-                      },
-                    }}
-                    trigger={['click']}>
-                    <span>
-                      <MoreOutlined
-                        className="event-list-more-icon"
-                        style={{ color: selectedItemId === eventItem?.id && '#1B3DE6' }}
-                        key={index}
-                      />
-                    </span>
-                  </Dropdown>
-                )
-              ) : (
+          return (
+            <List.Item
+              className="event-list-item-wrapper"
+              key={index}
+              actions={[
                 <EventStatusOptions
                   onOpenChange={(open) => {
                     if (open) setSelectedItemId(eventItem?.id);
@@ -148,7 +124,8 @@ function Lists(props) {
                   eventId={eventItem?.id}
                   updateEventState={updateEventState}
                   deleteEvent={deleteEvent}
-                  featureEvents={featureEvents}>
+                  featureEvents={featureEvents}
+                  onGetStructuredData={() => setStructuredDataEvent(eventItem)}>
                   <span>
                     <MoreOutlined
                       className="event-list-more-icon"
@@ -156,90 +133,77 @@ function Lists(props) {
                       key={index}
                     />
                   </span>
-                </EventStatusOptions>
-              ),
-            ]}
-            extra={[
-              <span key={index} className="event-list-options-responsive">
-                <EventStatusOptions
-                  key={index}
-                  publishState={eventItem?.publishState}
-                  eventData={eventItem}
-                  isFeatured={eventItem?.isFeatured}
-                  creator={eventItem?.creator}
-                  eventId={eventItem?.id}
-                  updateEventState={updateEventState}
-                  deleteEvent={deleteEvent}
-                  featureEvents={featureEvents}>
-                  <span>
-                    <MoreOutlined className="event-list-more-icon-responsive" key={index} />
-                  </span>
-                </EventStatusOptions>
-              </span>,
-            ]}>
-            <List.Item.Meta
-              className="event-list-item-meta"
-              onClick={() => {
-                navigate(`${location.pathname}/${eventItem?.id}`);
-              }}
-              avatar={
-                <>
-                  {screens.md && (
-                    <div className="event-list-image-wrapper">
-                      {(calendar[0]?.role === userRoles.ADMIN || user?.isSuperAdmin) && eventItem?.isFeatured && (
-                        <div className="image-featured-badge">
-                          <StarOutlined
-                            style={{
-                              fontSize: '12px',
-                              color: '#FFFFFF',
-                              position: 'absolute',
-                              top: '15%',
-                              left: '10%',
-                            }}
-                          />
-                        </div>
-                      )}
-                      <img
-                        src={eventItem?.image?.find((image) => image?.isMain)?.thumbnail?.uri}
-                        className="event-list-image"
-                        style={{
-                          border:
-                            (calendar[0]?.role === userRoles.ADMIN || user?.isSuperAdmin) &&
-                            eventItem?.isFeatured &&
-                            '3px solid #1B3DE6',
-                          width: `${imageDimensions.width}px`,
-                          height: `${imageDimensions.height}px`,
-                        }}
-                        data-cy="image-event-thumbnail"
-                      />
-                    </div>
-                  )}
-                </>
-              }
-              title={
-                <div className="event-list-title">
-                  <span className="event-list-title-heading" data-cy="span-start-date-time">
-                    {(eventItem?.startDate || eventItem?.startDateTime) &&
-                      moment
-                        .tz(eventItem?.startDate ?? eventItem?.startDateTime, scheduleTimezone)
-                        .locale(lang)
-                        .format(eventDateFormat)
-                        ?.toUpperCase()}
-
-                    {evenDateType === dateTypes.RANGE && (
-                      <>
-                        &nbsp;{t('dashboard.events.list.to')}&nbsp;
-                        {moment
-                          .tz(eventItem?.endDate ?? eventItem?.endDateTime, scheduleTimezone)
-                          .locale(lang)
-                          .format('DD-MMM-YYYY')
-                          ?.toUpperCase()}
-                      </>
+                </EventStatusOptions>,
+              ]}
+              extra={[
+                <span key={index} className="event-list-options-responsive">
+                  <EventStatusOptions
+                    key={index}
+                    publishState={eventItem?.publishState}
+                    eventData={eventItem}
+                    isFeatured={eventItem?.isFeatured}
+                    creator={eventItem?.creator}
+                    eventId={eventItem?.id}
+                    updateEventState={updateEventState}
+                    deleteEvent={deleteEvent}
+                    featureEvents={featureEvents}
+                    onGetStructuredData={() => setStructuredDataEvent(eventItem)}>
+                    <span>
+                      <MoreOutlined className="event-list-more-icon-responsive" key={index} />
+                    </span>
+                  </EventStatusOptions>
+                </span>,
+              ]}>
+              <List.Item.Meta
+                className="event-list-item-meta"
+                onClick={() => {
+                  navigate(`${location.pathname}/${eventItem?.id}`);
+                }}
+                avatar={
+                  <>
+                    {screens.md && (
+                      <div className="event-list-image-wrapper">
+                        {(calendar[0]?.role === userRoles.ADMIN || user?.isSuperAdmin) && eventItem?.isFeatured && (
+                          <div className="image-featured-badge">
+                            <StarOutlined
+                              style={{
+                                fontSize: '12px',
+                                color: '#FFFFFF',
+                                position: 'absolute',
+                                top: '15%',
+                                left: '10%',
+                              }}
+                            />
+                          </div>
+                        )}
+                        <img
+                          src={eventItem?.image?.find((image) => image?.isMain)?.thumbnail?.uri}
+                          className="event-list-image"
+                          style={{
+                            border:
+                              (calendar[0]?.role === userRoles.ADMIN || user?.isSuperAdmin) &&
+                              eventItem?.isFeatured &&
+                              '3px solid #1B3DE6',
+                            width: `${imageDimensions.width}px`,
+                            height: `${imageDimensions.height}px`,
+                          }}
+                          data-cy="image-event-thumbnail"
+                        />
+                      </div>
                     )}
-                    {evenDateType === dateTypes.MULTIPLE &&
-                      !moment
-                        .tz(eventItem?.startDate ?? eventItem?.startDateTime, scheduleTimezone)
-                        .isSame(moment.tz(eventItem?.endDate ?? eventItem?.endDateTime, scheduleTimezone), 'day') && (
+                  </>
+                }
+                title={
+                  <div className="event-list-title">
+                    <span className="event-list-title-heading" data-cy="span-start-date-time">
+                      {(eventItem?.startDate || eventItem?.startDateTime) &&
+                        moment
+                          .tz(eventItem?.startDate ?? eventItem?.startDateTime, scheduleTimezone)
+                          .locale(lang)
+                          .format(eventDateFormat)
+                          ?.toUpperCase()}
+
+                      {evenDateType === dateTypes.RANGE && (
                         <>
                           &nbsp;{t('dashboard.events.list.to')}&nbsp;
                           {moment
@@ -249,112 +213,126 @@ function Lists(props) {
                             ?.toUpperCase()}
                         </>
                       )}
-                  </span>
-                  &nbsp;&nbsp;
-                  {eventItem?.subEventDetails?.totalSubEventCount &&
-                  eventItem?.subEventDetails?.totalSubEventCount != 0 ? (
-                    <EventNumber label={eventItem?.subEventDetails?.totalSubEventCount} />
-                  ) : (
-                    <></>
-                  )}
-                  {(eventItem?.eventStatus === eventStatus.EventPostponed ||
-                    eventItem?.eventStatus === eventStatus.EventCancelled) && (
-                    <EventStatus label={eventItem?.eventStatus} />
-                  )}
-                </div>
-              }
-              description={
-                <div className="event-list-description">
-                  <div className="event-list-description-name-container">
-                    {!screens.md && eventItem?.isFeatured && (
-                      <span>
-                        <StarFilled style={{ color: '#1B3DE6' }} />
-                      </span>
-                    )}
-                    <span className="event-list-description-name" data-cy="span-event-name">
-                      {truncateText(
-                        contentLanguageBilingual({
-                          data: eventItem?.name,
-                          interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
-                          calendarContentLanguage: calendarContentLanguage,
-                        }),
-                        127,
-                      )}
+                      {evenDateType === dateTypes.MULTIPLE &&
+                        !moment
+                          .tz(eventItem?.startDate ?? eventItem?.startDateTime, scheduleTimezone)
+                          .isSame(moment.tz(eventItem?.endDate ?? eventItem?.endDateTime, scheduleTimezone), 'day') && (
+                          <>
+                            &nbsp;{t('dashboard.events.list.to')}&nbsp;
+                            {moment
+                              .tz(eventItem?.endDate ?? eventItem?.endDateTime, scheduleTimezone)
+                              .locale(lang)
+                              .format('DD-MMM-YYYY')
+                              ?.toUpperCase()}
+                          </>
+                        )}
                     </span>
+                    &nbsp;&nbsp;
+                    {eventItem?.subEventDetails?.totalSubEventCount &&
+                    eventItem?.subEventDetails?.totalSubEventCount != 0 ? (
+                      <EventNumber label={eventItem?.subEventDetails?.totalSubEventCount} />
+                    ) : (
+                      <></>
+                    )}
+                    {(eventItem?.eventStatus === eventStatus.EventPostponed ||
+                      eventItem?.eventStatus === eventStatus.EventCancelled) && (
+                      <EventStatus label={eventItem?.eventStatus} />
+                    )}
                   </div>
-                  <span className="event-list-description-place" data-cy="span-event-location">
-                    {eventItem?.location
-                      ?.map((place) => {
-                        return truncateText(
+                }
+                description={
+                  <div className="event-list-description">
+                    <div className="event-list-description-name-container">
+                      {!screens.md && eventItem?.isFeatured && (
+                        <span>
+                          <StarFilled style={{ color: '#1B3DE6' }} />
+                        </span>
+                      )}
+                      <span className="event-list-description-name" data-cy="span-event-name">
+                        {truncateText(
                           contentLanguageBilingual({
-                            data: place?.name,
+                            data: eventItem?.name,
                             interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
                             calendarContentLanguage: calendarContentLanguage,
                           }),
                           127,
-                        );
-                      })
-                      .join(' | ')}
-                  </span>
-                </div>
-              }
-            />
-            <List.Item.Meta
-              className="event-status-list-item"
-              onClick={() => {
-                navigate(`${location.pathname}/${eventItem?.id}`);
-              }}
-              title={
-                <div className="event-status-list-item-title-container">
-                  <EventStatus label={eventItem?.publishState} />
-                  {artsDataLinkChecker(eventItem)?.length > 0 && (
-                    <div className="artsdata-link-outlined-icon" data-cy="artsdata-link-outlined-icon">
-                      <Link
-                        href={artsDataLinkChecker(eventItem)[0]?.uri}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        onClick={(e) => e.stopPropagation()}>
-                        <LinkOutlined style={{ fontSize: '14px' }} />
-                      </Link>
+                        )}
+                      </span>
                     </div>
-                  )}
-                </div>
-              }
-              description={
-                <div className="event-list-status" data-cy="span-event-creator">
-                  <span className="event-list-status-created-by">
-                    {t('dashboard.events.list.createdBy')}&nbsp;
-                    {moment
-                      .tz(eventItem?.creator?.date, scheduleTimezone)
-                      .locale(lang)
-                      .format('DD-MMM-YYYY')
-                      ?.toUpperCase()}
-                    &nbsp;
-                    {t('dashboard.events.list.by')}&nbsp;
-                    <Username userName={eventItem?.creator?.userName} data-cy="span-event-creator-username" />
-                  </span>
-                  {eventItem?.modifier?.userName ? (
-                    <span className="event-list-status-updated-by" data-cy="span-event-modifier">
-                      {t('dashboard.events.list.updatedBy')}&nbsp;
+                    <span className="event-list-description-place" data-cy="span-event-location">
+                      {eventItem?.location
+                        ?.map((place) => {
+                          return truncateText(
+                            contentLanguageBilingual({
+                              data: place?.name,
+                              interfaceLanguage: user?.interfaceLanguage?.toLowerCase(),
+                              calendarContentLanguage: calendarContentLanguage,
+                            }),
+                            127,
+                          );
+                        })
+                        .join(' | ')}
+                    </span>
+                  </div>
+                }
+              />
+              <List.Item.Meta
+                className="event-status-list-item"
+                onClick={() => {
+                  navigate(`${location.pathname}/${eventItem?.id}`);
+                }}
+                title={
+                  <div className="event-status-list-item-title-container">
+                    <EventStatus label={eventItem?.publishState} />
+                    {artsDataLinkChecker(eventItem)?.length > 0 && (
+                      <div className="artsdata-link-outlined-icon" data-cy="artsdata-link-outlined-icon">
+                        <Link
+                          href={artsDataLinkChecker(eventItem)[0]?.uri}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}>
+                          <LinkOutlined style={{ fontSize: '14px' }} />
+                        </Link>
+                      </div>
+                    )}
+                  </div>
+                }
+                description={
+                  <div className="event-list-status" data-cy="span-event-creator">
+                    <span className="event-list-status-created-by">
+                      {t('dashboard.events.list.createdBy')}&nbsp;
                       {moment
-                        .tz(eventItem?.modifier?.date, scheduleTimezone)
+                        .tz(eventItem?.creator?.date, scheduleTimezone)
                         .locale(lang)
                         .format('DD-MMM-YYYY')
                         ?.toUpperCase()}
                       &nbsp;
                       {t('dashboard.events.list.by')}&nbsp;
-                      <Username userName={eventItem?.modifier?.userName} data-cy="span-event-modifier-username" />
+                      <Username userName={eventItem?.creator?.userName} data-cy="span-event-creator-username" />
                     </span>
-                  ) : (
-                    <></>
-                  )}
-                </div>
-              }
-            />
-          </List.Item>
-        );
-      }}
-    />
+                    {eventItem?.modifier?.userName ? (
+                      <span className="event-list-status-updated-by" data-cy="span-event-modifier">
+                        {t('dashboard.events.list.updatedBy')}&nbsp;
+                        {moment
+                          .tz(eventItem?.modifier?.date, scheduleTimezone)
+                          .locale(lang)
+                          .format('DD-MMM-YYYY')
+                          ?.toUpperCase()}
+                        &nbsp;
+                        {t('dashboard.events.list.by')}&nbsp;
+                        <Username userName={eventItem?.modifier?.userName} data-cy="span-event-modifier-username" />
+                      </span>
+                    ) : (
+                      <></>
+                    )}
+                  </div>
+                }
+              />
+            </List.Item>
+          );
+        }}
+      />
+    </>
   );
 }
 

--- a/src/components/StructuredDataModal/StructuredDataModal.jsx
+++ b/src/components/StructuredDataModal/StructuredDataModal.jsx
@@ -1,0 +1,165 @@
+import React, { useEffect, useState } from 'react';
+import { Alert, Skeleton, Typography, notification } from 'antd';
+import { useTranslation } from 'react-i18next';
+import CustomModal from '../Modal/Common/CustomModal';
+import StyledSwitch from '../Switch/StyledSwitch';
+import PrimaryButton from '../Button/Primary';
+import OutlinedButton from '../Button/Outlined';
+import { getEventStructuredData } from '../../services/structuredData';
+import './structuredDataModal.css';
+
+const StructuredDataModal = ({ visible, onCancel, eventId, eventName }) => {
+  const { t } = useTranslation();
+
+  const [wrapInScript, setWrapInScript] = useState(true);
+  const [jsonLd, setJsonLd] = useState(null);
+  const [isSeries, setIsSeries] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [fetchCount, setFetchCount] = useState(0);
+
+  useEffect(() => {
+    if (!visible || !eventId) return;
+    let active = true;
+    setIsLoading(true);
+    setError(null);
+    getEventStructuredData({ eventId })
+      .then((result) => {
+        if (!active) return;
+        setJsonLd(result.jsonLd);
+        setIsSeries(result.isSeries);
+        setIsLoading(false);
+      })
+      .catch((fetchError) => {
+        if (!active) return;
+        setError(fetchError?.code ?? 'generic');
+        setIsLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [visible, eventId, fetchCount]);
+
+  const displayedText = wrapInScript ? `<script type="application/ld+json">\n${jsonLd}\n</script>` : jsonLd;
+
+  const errorMessageKeys = {
+    notFound: 'dashboard.events.structuredData.errorNotFound',
+    network: 'dashboard.events.structuredData.errorNetwork',
+    invalid: 'dashboard.events.structuredData.errorInvalid',
+  };
+
+  const actionsDisabled = isLoading || !!error || !jsonLd;
+
+  const handleCopy = async () => {
+    if (actionsDisabled) return;
+    await navigator.clipboard.writeText(displayedText);
+    notification.success({
+      description: t('dashboard.events.structuredData.copied'),
+      placement: 'top',
+      closeIcon: <></>,
+      maxCount: 1,
+      duration: 3,
+    });
+  };
+
+  const handleDownload = () => {
+    if (actionsDisabled) return;
+    const blob = new Blob([displayedText], { type: 'application/ld+json' });
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `event-${eventId}.jsonld`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  };
+
+  const handleCancel = () => {
+    setWrapInScript(true);
+    setError(null);
+    onCancel();
+  };
+
+  return (
+    <CustomModal
+      visible={visible}
+      onCancel={handleCancel}
+      centered
+      width={700}
+      className="structured-data-modal"
+      title={
+        <Typography.Title level={5} style={{ margin: 0, color: '#1f2635' }}>
+          {t('dashboard.events.structuredData.title')}
+        </Typography.Title>
+      }
+      footer={
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px', alignItems: 'center' }}>
+          <OutlinedButton
+            data-cy="button-structured-data-download"
+            label={t('dashboard.events.structuredData.download')}
+            disabled={actionsDisabled}
+            onClick={handleDownload}
+          />
+          <PrimaryButton
+            data-cy="button-structured-data-copy"
+            label={t('dashboard.events.structuredData.copy')}
+            disabled={actionsDisabled}
+            onClick={handleCopy}
+          />
+        </div>
+      }>
+      <div className="structured-data-modal-content">
+        <p className="structured-data-help">{t('dashboard.events.structuredData.help')}</p>
+
+        <div className="switch-wrapper-container">
+          <StyledSwitch
+            data-cy="switch-structured-data-wrap"
+            checked={wrapInScript}
+            onChange={(checked) => setWrapInScript(checked)}
+            disabled={isLoading || !!error}
+          />
+          <span className="switch-label">{t('dashboard.events.structuredData.wrapScript')}</span>
+        </div>
+
+        {isLoading ? (
+          <Skeleton active paragraph={{ rows: 8 }} title={false} data-cy="skeleton-structured-data" />
+        ) : error ? (
+          <Alert
+            data-cy="alert-structured-data-error"
+            type="error"
+            showIcon
+            message={t(errorMessageKeys[error] ?? 'dashboard.events.structuredData.error')}
+            action={
+              <OutlinedButton
+                data-cy="button-structured-data-retry"
+                size="small"
+                label={t('dashboard.events.structuredData.retry')}
+                onClick={() => setFetchCount((count) => count + 1)}
+              />
+            }
+          />
+        ) : (
+          jsonLd && (
+            <>
+              {isSeries && (
+                <Alert
+                  data-cy="alert-structured-data-series"
+                  className="structured-data-series-note"
+                  type="warning"
+                  showIcon
+                  message={t('dashboard.events.structuredData.seriesNote')}
+                />
+              )}
+              <pre className="structured-data-code" aria-label={eventName} data-cy="code-structured-data">
+                {displayedText}
+              </pre>
+            </>
+          )
+        )}
+      </div>
+    </CustomModal>
+  );
+};
+
+export default StructuredDataModal;

--- a/src/components/StructuredDataModal/index.js
+++ b/src/components/StructuredDataModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './StructuredDataModal';

--- a/src/components/StructuredDataModal/structuredDataModal.css
+++ b/src/components/StructuredDataModal/structuredDataModal.css
@@ -1,0 +1,46 @@
+.structured-data-modal .ant-modal-body {
+  overflow-x: hidden;
+}
+
+.structured-data-modal .structured-data-modal-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 100%;
+}
+
+.structured-data-modal .structured-data-help {
+  margin: 0;
+  color: #646d7b;
+  font-size: 14px;
+}
+
+.structured-data-modal .switch-wrapper-container {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.structured-data-modal .switch-wrapper-container .switch-label {
+  font-size: 14px;
+  color: #1f2635;
+}
+
+.structured-data-modal .structured-data-series-note {
+  margin-bottom: 0;
+}
+
+.structured-data-modal .structured-data-code {
+  margin: 0;
+  padding: 12px;
+  max-height: 45vh;
+  overflow: auto;
+  white-space: pre;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  background-color: #f7f8fa;
+  border: 1px solid #e3e5e8;
+  border-radius: 4px;
+  color: #1f2635;
+}

--- a/src/locales/en/translationEn.json
+++ b/src/locales/en/translationEn.json
@@ -504,7 +504,24 @@
         "unFeatureEvent": "Unfeature this event",
         "deleteEvent": "Delete event",
         "duplicateEvent": "Duplicate Event",
-        "revertToDraft": "Revert to draft"
+        "revertToDraft": "Revert to draft",
+        "copyJsonLd": "Copy JSON-LD"
+      },
+      "structuredData": {
+        "title": "Structured data for your website",
+        "help": "Paste this into an HTML block on your event page.",
+        "getStructuredData": "Get structured data",
+        "wrapScript": "Wrap in <script type=\"application/ld+json\">",
+        "copy": "Copy to clipboard",
+        "copied": "Structured data copied to clipboard",
+        "download": "Download .jsonld",
+        "close": "Close",
+        "error": "Something went wrong while generating the structured data.",
+        "errorNotFound": "This event could not be found. It may have been deleted.",
+        "errorNetwork": "Could not reach the server. Check your connection and try again.",
+        "errorInvalid": "The server did not return usable structured data for this event. Try again, and contact support if it persists.",
+        "retry": "Retry",
+        "seriesNote": "This snippet covers the event series itself — its individual dates are not included."
       },
       "publishState": {
         "published": "Published",

--- a/src/locales/fr/transalationFr.json
+++ b/src/locales/fr/transalationFr.json
@@ -505,7 +505,24 @@
         "duplicateEvent": "Dupliquer l’événement",
         "featureEvent": "Mettre en vedette",
         "unFeatureEvent": "Retirer la mise en vedette",
-        "revertToDraft": "Revenir au brouillon"
+        "revertToDraft": "Revenir au brouillon",
+        "copyJsonLd": "Copier le JSON-LD"
+      },
+      "structuredData": {
+        "title": "Données structurées pour votre site web",
+        "help": "Collez ceci dans un bloc HTML sur la page de votre événement.",
+        "getStructuredData": "Obtenir les données structurées",
+        "wrapScript": "Envelopper dans <script type=\"application/ld+json\">",
+        "copy": "Copier dans le presse-papiers",
+        "copied": "Données structurées copiées dans le presse-papiers",
+        "download": "Télécharger le .jsonld",
+        "close": "Fermer",
+        "error": "Une erreur est survenue lors de la génération des données structurées.",
+        "errorNotFound": "Cet événement est introuvable. Il a peut-être été supprimé.",
+        "errorNetwork": "Impossible de joindre le serveur. Vérifiez votre connexion et réessayez.",
+        "errorInvalid": "Le serveur n’a pas retourné de données structurées utilisables pour cet événement. Réessayez et contactez le soutien si le problème persiste.",
+        "retry": "Réessayer",
+        "seriesNote": "Cet extrait couvre la série d’événements elle-même — ses dates individuelles ne sont pas incluses."
       },
       "publishState": {
         "published": "Publié",

--- a/src/pages/Dashboard/EventReadOnly/EventReadOnly.jsx
+++ b/src/pages/Dashboard/EventReadOnly/EventReadOnly.jsx
@@ -59,6 +59,7 @@ import FallbackInjectorForReadOnlyPages from '../../../components/FallbackInject
 import { getLabelByTimezoneValue } from '../../../utils/handleTimeZones';
 import { Translation } from 'react-i18next';
 import LoadingIndicator from '../../../components/LoadingIndicator/LoadingIndicator';
+import StructuredDataModal from '../../../components/StructuredDataModal';
 import '../../../components/NoContent/noContent.css';
 import {
   isReadOnlyValueEmpty,
@@ -116,6 +117,7 @@ function EventReadOnly() {
   const [debouncedLoading, setDebouncedLoading] = useState(true);
   const [artsData, setArtsData] = useState(null);
   const [artsDataLoading, setArtsDataLoading] = useState(false);
+  const [structuredDataOpen, setStructuredDataOpen] = useState(false);
 
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -376,6 +378,16 @@ function EventReadOnly() {
 
   return !debouncedLoading ? (
     <div>
+      <StructuredDataModal
+        visible={structuredDataOpen}
+        onCancel={() => setStructuredDataOpen(false)}
+        eventId={eventId}
+        eventName={contentLanguageBilingual({
+          data: eventData?.name,
+          requiredLanguageKey: user?.interfaceLanguage?.toLowerCase(),
+          calendarContentLanguage: calendarContentLanguage,
+        })}
+      />
       <Row gutter={[32, 24]} className="read-only-wrapper events-read-only-wrapper " style={{ margin: 0 }}>
         <div className="event-read-only-sticky-header" ref={stickyHeaderRef}>
           <Col className="top-level-column" span={24}>
@@ -389,12 +401,19 @@ function EventReadOnly() {
                   })}
                 />
               </Col>
-              <Col flex="60px" style={{ marginLeft: 'auto' }}>
-                <ReadOnlyProtectedComponent
-                  creator={eventData.createdByUserId}
-                  isReadOnly={isReadOnly}
-                  eventState={eventData?.publishState}>
-                  <div className="button-container">
+              <Col flex="none" style={{ marginLeft: 'auto' }}>
+                <div className="button-container" style={{ display: 'flex', gap: '8px' }}>
+                  <OutlinedButton
+                    data-cy="button-get-structured-data"
+                    label={t('dashboard.events.structuredData.getStructuredData')}
+                    size="middle"
+                    style={{ height: '40px' }}
+                    onClick={() => setStructuredDataOpen(true)}
+                  />
+                  <ReadOnlyProtectedComponent
+                    creator={eventData.createdByUserId}
+                    isReadOnly={isReadOnly}
+                    eventState={eventData?.publishState}>
                     <OutlinedButton
                       data-cy="button-edit-place"
                       label={t('dashboard.places.readOnly.edit')}
@@ -409,8 +428,8 @@ function EventReadOnly() {
                         )
                       }
                     />
-                  </div>
-                </ReadOnlyProtectedComponent>
+                  </ReadOnlyProtectedComponent>
+                </div>
               </Col>
             </Row>
           </Col>

--- a/src/services/structuredData.js
+++ b/src/services/structuredData.js
@@ -1,0 +1,49 @@
+// Draft events work because the Open API's event-detail route has no publishState guard —
+// an accepted WB1 dependency (see WB1_Schema_Structured_Data_Generator_Design.md). If a guard
+// is added in footlight-calendar-api (ticket: TODO link once filed), this breaks for drafts.
+
+import { normalizeEventJsonLd } from '../utils/normalizeEventJsonLd';
+
+const structuredDataError = (code, message) => Object.assign(new Error(message ?? code), { code });
+
+export const getEventStructuredData = async ({ eventId } = {}) => {
+  const baseUrl = import.meta.env.VITE_APP_OPEN_API_URL;
+
+  let response;
+  try {
+    response = await fetch(`${baseUrl}/events/${eventId}?include-json-ld=true`, {
+      headers: { accept: 'application/json' },
+    });
+  } catch (networkError) {
+    throw structuredDataError('network', networkError?.message);
+  }
+
+  if (response.status === 404 || response.status === 400) throw structuredDataError('notFound');
+  if (!response.ok) throw structuredDataError('network', `Unexpected response status ${response.status}`);
+
+  let body;
+  try {
+    body = await response.json();
+  } catch (parseError) {
+    throw structuredDataError('invalid', 'Response body is not valid JSON');
+  }
+
+  const rawJsonLd = body?.data?.jsonld;
+  if (typeof rawJsonLd !== 'string' || rawJsonLd.trim() === '')
+    throw structuredDataError('invalid', 'Response has no data.jsonld');
+
+  let parsedJsonLd;
+  try {
+    parsedJsonLd = JSON.parse(rawJsonLd);
+  } catch (parseError) {
+    throw structuredDataError('invalid', 'data.jsonld is not parseable JSON');
+  }
+
+  const isSeries =
+    (body?.data?.subEvent?.length ?? 0) > 0 || (body?.data?.subEventDetails?.totalSubEventCount ?? 0) > 0;
+
+  return {
+    jsonLd: JSON.stringify(normalizeEventJsonLd(parsedJsonLd), null, 2),
+    isSeries,
+  };
+};

--- a/src/utils/normalizeEventJsonLd.js
+++ b/src/utils/normalizeEventJsonLd.js
@@ -4,7 +4,6 @@ export const normalizeEventJsonLd = (parsedJsonLd) => {
   if (!isPlainObject(parsedJsonLd)) return parsedJsonLd;
 
   const normalized = { ...parsedJsonLd };
-  delete normalized.mainEntityOfPage;
 
   return normalized;
 };

--- a/src/utils/normalizeEventJsonLd.js
+++ b/src/utils/normalizeEventJsonLd.js
@@ -1,0 +1,10 @@
+const isPlainObject = (value) => typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const normalizeEventJsonLd = (parsedJsonLd) => {
+  if (!isPlainObject(parsedJsonLd)) return parsedJsonLd;
+
+  const normalized = { ...parsedJsonLd };
+  delete normalized.mainEntityOfPage;
+
+  return normalized;
+};


### PR DESCRIPTION
## Summary

Adds support for copying and downloading event JSON-LD structured data for embedding on external sites.

## Changes

* Added `StructuredDataModal` with:

  * JSON-LD preview
  * Toggle to wrap JSON-LD in a `<script>` tag
  * Copy to clipboard
  * `.jsonld` file download
* Added `getEventStructuredData` service to fetch event structured data via:
  `GET /events/{id}?include-json-ld=true`
* Updated Event List and read-only Event View to expose:

  * **Get structured data**
  * **Copy JSON-LD**
* Refactored `EventStatus` dropdown to use inline `writeTier` instead of `ProtectedComponents`.

  * Read actions are always visible.
  * Write actions remain RBAC-gated.
* Added EN/FR i18n keys for structured data functionality.
* Added `VITE_APP_OPEN_API_URL` to the staging environment configuration.
