### PR TITLE
fix: new calendar creation integration

### DIFF
--- a/src/components/Dropdown/Calendar/Calendar.jsx
+++ b/src/components/Dropdown/Calendar/Calendar.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import './calendar.css';
 import { Dropdown, Input } from 'antd';
-import { SearchOutlined } from '@ant-design/icons';
+import { SearchOutlined, PlusOutlined } from '@ant-design/icons';
 import Cookies from 'js-cookie';
 import { useDispatch, useSelector } from 'react-redux';
 import { setSelectedCalendar } from '../../../redux/reducer/selectedCalendarSlice';
@@ -14,6 +14,7 @@ import { SEARCH_DELAY } from '../../../constants/search';
 import { useLazyGetAllCalendarsQuery } from '../../../services/calendar';
 import { setRecentCalendarForUser } from '../../../utils/recentCalendarStorage';
 import LoadingIndicator from '../../LoadingIndicator';
+import CreateCalendar from '../../Modal/CreateCalendar';
 
 const hashString = (value = '') => {
   let hash = 0;
@@ -57,6 +58,7 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
   const [getAllCalendars, { isFetching }] = useLazyGetAllCalendarsQuery();
 
   const [open, setOpen] = useState(false);
+  const [createModalOpen, setCreateModalOpen] = useState(false);
   const [searchInput, setSearchInput] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
   const [activeSearchTerm, setActiveSearchTerm] = useState('');
@@ -354,19 +356,36 @@ function Calendar({ children, setPageNumber, allCalendarsData }) {
           <div className="calendar-empty-state">{t('dashboard.calendar.noCalendarsFound')}</div>
         )}
       </div>
+      {user?.isSuperAdmin && (
+        <div className="calendar-create-footer">
+          <button
+            className="calendar-create-button"
+            data-cy="button-create-new-calendar"
+            onClick={() => {
+              setOpen(false);
+              setCreateModalOpen(true);
+            }}>
+            <PlusOutlined style={{ marginRight: 6 }} />
+            {t('dashboard.calendar.createCalendar.createButton')}
+          </button>
+        </div>
+      )}
     </div>
   );
 
   return (
-    <Dropdown
-      open={open}
-      onOpenChange={handleOpenChange}
-      trigger={['click']}
-      overlayClassName="calendar-dropdown-overlay"
-      dropdownRender={renderDropdown}
-      getPopupContainer={(trigger) => trigger.parentNode}>
-      {children}
-    </Dropdown>
+    <>
+      <Dropdown
+        open={open}
+        onOpenChange={handleOpenChange}
+        trigger={['click']}
+        overlayClassName="calendar-dropdown-overlay"
+        dropdownRender={renderDropdown}
+        getPopupContainer={(trigger) => trigger.parentNode}>
+        {children}
+      </Dropdown>
+      {user?.isSuperAdmin && <CreateCalendar open={createModalOpen} setOpen={setCreateModalOpen} />}
+    </>
   );
 }
 

--- a/src/components/Dropdown/Calendar/calendar.css
+++ b/src/components/Dropdown/Calendar/calendar.css
@@ -107,3 +107,28 @@
   color: #646d7b;
   font-size: 14px;
 }
+
+.calendar-create-footer {
+  border-top: 1px solid #b6c1c9;
+  padding: 12px;
+  display: flex;
+  justify-content: center;
+}
+
+.calendar-create-button {
+  width: 100%;
+  border: 1px solid #1b3de6;
+  color: #1b3de6;
+  background: #fff;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.calendar-create-button:hover {
+  background: #eff2ff;
+}

--- a/src/components/Modal/CreateCalendar/CreateCalendar.jsx
+++ b/src/components/Modal/CreateCalendar/CreateCalendar.jsx
@@ -1,0 +1,248 @@
+import React from 'react';
+import { Form, Input, notification, message } from 'antd';
+import { useTranslation } from 'react-i18next';
+import { useDispatch, useSelector } from 'react-redux';
+import { CloseCircleOutlined } from '@ant-design/icons';
+import CustomModal from '../Common/CustomModal';
+import { useAddCalendarMutation } from '../../../services/calendar';
+import { calendarLanguages, contentLanguageKeyMap } from '../../../constants/contentLanguage';
+import { timeZones, dateFormats } from '../../../constants/calendarSettingsForm';
+import Select from '../../Select';
+import TreeSelectOption from '../../TreeSelectOption';
+import Tags from '../../Tags/Common/Tags';
+import NoContent from '../../NoContent/NoContent';
+import StyledInput from '../../Input/Common';
+import CreateMultiLingualFormItems from '../../../layout/CreateMultiLingualFormItems/CreateMultiLingualFormItems';
+import { setSelectedCalendar } from '../../../redux/reducer/selectedCalendarSlice';
+import { setRecentCalendarForUser } from '../../../utils/recentCalendarStorage';
+import { getUserDetails } from '../../../redux/reducer/userSlice';
+import { PathName } from '../../../constants/pathName';
+import './createCalendar.css';
+
+function CreateCalendar({ open, setOpen }) {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const { user } = useSelector(getUserDetails);
+  const [form] = Form.useForm();
+  const [addCalendar, { isLoading }] = useAddCalendarMutation();
+
+  const contentLanguage = Form.useWatch('contentLanguage', form);
+  const namePlaceholder = t('dashboard.calendar.createCalendar.namePlaceholder');
+  const namePlaceholderMap =
+    contentLanguage && contentLanguage.length > 0
+      ? Object.fromEntries(contentLanguage.map((lang) => [contentLanguageKeyMap[lang], namePlaceholder]))
+      : namePlaceholder;
+
+  const handleCancel = () => {
+    form.resetFields();
+    setOpen(false);
+  };
+
+  const handleFinish = async () => {
+    try {
+      const values = await form.validateFields();
+
+      const dto = {
+        name: values.name,
+        contentLanguage: values.contentLanguage,
+      };
+
+      if (values.contact) dto.contact = values.contact;
+      if (values.timezone) dto.timezone = values.timezone;
+      if (values.dateFormatDisplay) dto.dateFormatDisplay = values.dateFormatDisplay;
+
+      if (values.eventTemplate || values.searchResultTemplate) {
+        dto.widgetSettings = {};
+        if (values.eventTemplate) dto.widgetSettings.eventDetailsUrlTemplate = values.eventTemplate;
+        if (values.searchResultTemplate) dto.widgetSettings.listEventsUrlTemplate = values.searchResultTemplate;
+      }
+
+      const response = await addCalendar({ data: dto }).unwrap();
+      const id = response?.id ?? response?.data?.id;
+
+      notification.success({
+        description: t('dashboard.calendar.createCalendar.success'),
+        placement: 'top',
+        closeIcon: <></>,
+        maxCount: 1,
+        duration: 3,
+      });
+
+      form.resetFields();
+      setOpen(false);
+
+      if (id) {
+        dispatch(setSelectedCalendar(String(id)));
+        setRecentCalendarForUser({ user, calendarId: id });
+        sessionStorage.clear();
+        sessionStorage.setItem('calendarId', String(id));
+        const origin = window.location.origin;
+        const newUrl = `${origin}${PathName.Dashboard}/${id}${PathName.Events}`;
+        window.location.href = newUrl;
+      }
+    } catch (error) {
+      if (error?.errorFields) {
+        return;
+      }
+      const status = error?.status;
+      if (status === 409) {
+        message.warning(t('dashboard.calendar.createCalendar.duplicate'));
+      } else if (status) {
+        const serverMsg = error?.data?.message || error?.data?.error;
+        if (serverMsg) message.warning(serverMsg);
+      }
+    }
+  };
+
+  return (
+    <CustomModal
+      open={open}
+      onCancel={handleCancel}
+      centered
+      width={600}
+      title={<span className="create-calendar-modal-title">{t('dashboard.calendar.createCalendar.modalTitle')}</span>}
+      destroyOnClose
+      footer={null}
+      wrapClassName="create-calendar-modal-wrapper"
+      className="create-calendar-modal">
+      <Form form={form} layout="vertical" preserve={false} className="create-calendar-form">
+        <Form.Item
+          name="contentLanguage"
+          label={
+            <span className="create-calendar-label">{t('dashboard.calendar.createCalendar.contentLanguage')}</span>
+          }
+          rules={[{ required: true, message: t('common.validations.informationRequired') }]}
+          data-cy="form-item-create-calendar-content-language">
+          <TreeSelectOption
+            showSearch={false}
+            allowClear
+            treeDefaultExpandAll
+            multiple
+            placeholder={t('dashboard.settings.calendarSettings.placeholders.calendarLanguage')}
+            notFoundContent={<NoContent />}
+            clearIcon={<CloseCircleOutlined style={{ color: '#1b3de6', fontSize: '14px' }} />}
+            treeData={calendarLanguages}
+            data-cy="treeselect-create-calendar-language"
+            tagRender={(props) => {
+              const { closable, onClose, label } = props;
+              return (
+                <Tags
+                  data-cy={`tag-create-calendar-language-${label}`}
+                  closable={closable}
+                  onClose={onClose}
+                  closeIcon={<CloseCircleOutlined style={{ color: '#1b3de6', fontSize: '12px' }} />}>
+                  {label}
+                </Tags>
+              );
+            }}
+          />
+        </Form.Item>
+
+        {contentLanguage && contentLanguage.length > 0 ? (
+          <CreateMultiLingualFormItems
+            calendarContentLanguage={contentLanguage}
+            form={form}
+            name="name"
+            data={{}}
+            validations={t('common.validations.informationRequired')}
+            required={true}
+            placeholder={namePlaceholderMap}
+            data-cy="input-create-calendar-name">
+            <StyledInput data-cy="input-create-calendar-name-input" />
+          </CreateMultiLingualFormItems>
+        ) : (
+          <Form.Item
+            label={<span className="create-calendar-label">{t('dashboard.calendar.createCalendar.name')}</span>}
+            required>
+            <Input disabled placeholder={t('dashboard.calendar.createCalendar.namePlaceholderWhenNoLanguage')} />
+          </Form.Item>
+        )}
+
+        <Form.Item
+          name="contact"
+          label={t('dashboard.calendar.createCalendar.contact')}
+          rules={[{ type: 'email', message: t('login.validations.invalidEmail') }]}
+          data-cy="form-item-create-calendar-contact">
+          <StyledInput
+            placeholder={t('dashboard.settings.calendarSettings.placeholders.contact')}
+            data-cy="input-create-calendar-contact"
+          />
+        </Form.Item>
+
+        <Form.Item
+          name="timezone"
+          label={t('dashboard.calendar.createCalendar.timezone')}
+          data-cy="form-item-create-calendar-timezone">
+          <Select
+            options={timeZones}
+            placeholder={t('dashboard.settings.calendarSettings.placeholders.timezone')}
+            data-cy="select-create-calendar-timezone"
+          />
+        </Form.Item>
+
+        <Form.Item
+          name="dateFormatDisplay"
+          label={t('dashboard.calendar.createCalendar.dateFormat')}
+          data-cy="form-item-create-calendar-date-format">
+          <Select
+            options={dateFormats}
+            placeholder={t('dashboard.settings.calendarSettings.placeholders.dateFormatDisplay')}
+            data-cy="select-create-calendar-date-format"
+          />
+        </Form.Item>
+
+        <Form.Item
+          name="eventTemplate"
+          label={t('dashboard.calendar.createCalendar.eventTemplate')}
+          rules={[{ type: 'url', message: t('dashboard.events.addEditEvent.validations.url') }]}
+          extra={
+            <span className="create-calendar-help">
+              {t('dashboard.settings.calendarSettings.eventTemplateDescription')}
+            </span>
+          }
+          data-cy="form-item-create-calendar-event-template">
+          <StyledInput
+            addonBefore="URL"
+            autoComplete="off"
+            placeholder={t('dashboard.settings.calendarSettings.placeholders.eventTemplate')}
+            data-cy="input-create-calendar-event-template"
+          />
+        </Form.Item>
+
+        <Form.Item
+          name="searchResultTemplate"
+          label={t('dashboard.calendar.createCalendar.searchResultTemplate')}
+          rules={[{ type: 'url', message: t('dashboard.events.addEditEvent.validations.url') }]}
+          extra={
+            <span className="create-calendar-help">
+              {t('dashboard.settings.calendarSettings.searchResultTemplateDescription')}
+            </span>
+          }
+          data-cy="form-item-create-calendar-search-result-template">
+          <StyledInput
+            addonBefore="URL"
+            autoComplete="off"
+            placeholder={t('dashboard.settings.calendarSettings.placeholders.searchResultTemplate')}
+            data-cy="input-create-calendar-search-result-template"
+          />
+        </Form.Item>
+
+        <div className="create-calendar-footer">
+          <a onClick={handleCancel} className="create-calendar-cancel">
+            {t('dashboard.calendar.createCalendar.cancel')}
+          </a>
+          <button
+            type="button"
+            className="create-calendar-submit-btn"
+            onClick={handleFinish}
+            disabled={isLoading}
+            data-cy="button-create-calendar-submit">
+            {isLoading ? t('common.creating') || 'Creating...' : t('dashboard.calendar.createCalendar.create')}
+          </button>
+        </div>
+      </Form>
+    </CustomModal>
+  );
+}
+
+export default CreateCalendar;

--- a/src/components/Modal/CreateCalendar/createCalendar.css
+++ b/src/components/Modal/CreateCalendar/createCalendar.css
@@ -1,0 +1,77 @@
+.create-calendar-modal-title {
+  font-weight: 700;
+  font-size: 20px;
+  color: #222732;
+}
+
+.create-calendar-modal .create-calendar-form .ant-form-item-label > label {
+  font-weight: 700;
+  font-size: 14px;
+  color: #222732;
+}
+
+.create-calendar-label {
+  font-weight: 700;
+  font-size: 14px;
+  color: #222732;
+}
+
+.create-calendar-help {
+  font-size: 12px;
+  color: #646d7b;
+}
+
+.create-calendar-footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.create-calendar-cancel {
+  color: #1b3de6;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.create-calendar-submit-btn {
+  background: #1b3de6;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 8px 24px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.create-calendar-submit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.create-calendar-modal-wrapper .ant-modal-content {
+  border-radius: 8px;
+}
+
+.calendar-create-footer {
+  border-top: 1px solid #b6c1c9;
+  padding: 12px 12px;
+  display: flex;
+  justify-content: center;
+}
+
+.calendar-create-button {
+  width: 100%;
+  border: 1px solid #1b3de6;
+  color: #1b3de6;
+  background: #fff;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.calendar-create-button:hover {
+  background: #eff2ff;
+}

--- a/src/components/Modal/CreateCalendar/index.js
+++ b/src/components/Modal/CreateCalendar/index.js
@@ -1,0 +1,1 @@
+export { default } from './CreateCalendar';

--- a/src/components/MultilingualInput/MultilingualInput.jsx
+++ b/src/components/MultilingualInput/MultilingualInput.jsx
@@ -46,7 +46,13 @@ function MultilingualInput({ children, ...rest }) {
     entityId,
     form,
   } = rest;
-  const [currentCalendarData] = useOutletContext();
+  let currentCalendarData = null;
+  try {
+    const outletContext = useOutletContext();
+    currentCalendarData = Array.isArray(outletContext) ? outletContext[0] : outletContext;
+  } catch {
+    currentCalendarData = null;
+  }
   const { t } = useTranslation();
   const [activeKey, setActiveKey] = React.useState(defaultTabProp);
 

--- a/src/constants/calendarSettingsForm.js
+++ b/src/constants/calendarSettingsForm.js
@@ -79,7 +79,7 @@ export const timeZones = [
   },
 ];
 
-const dateFormats = [
+export const dateFormats = [
   {
     label: 'MM/DD/YYYY',
     value: 'MM/DD/YYYY',

--- a/src/locales/en/translationEn.json
+++ b/src/locales/en/translationEn.json
@@ -75,6 +75,23 @@
         "readOnlyMode": "Read-only mode",
         "heading": "Calendar in read only mode",
         "content": "The calendar is currently read only. Editing is unavailable for users. Try again later or contact your admin at {{adminEmail}} for details."
+      },
+      "createCalendar": {
+        "createButton": "Create new calendar",
+        "modalTitle": "Create calendar",
+        "contentLanguage": "Languages",
+        "name": "Name",
+        "namePlaceholder": "Enter calendar name",
+        "namePlaceholderWhenNoLanguage": "Select languages first",
+        "contact": "Contact",
+        "timezone": "Time zone",
+        "dateFormat": "Date format display",
+        "eventTemplate": "Event template",
+        "searchResultTemplate": "Search results template",
+        "cancel": "Cancel",
+        "create": "Create",
+        "success": "Calendar created successfully",
+        "duplicate": "A calendar with this name already exists"
       }
     },
     "topNavigation": {

--- a/src/locales/fr/transalationFr.json
+++ b/src/locales/fr/transalationFr.json
@@ -75,6 +75,23 @@
         "readOnlyMode": "Mode lecture seule",
         "heading": "Calendrier en mode lecture seule",
         "content": "Le calendrier est actuellement en mode lecture seule. Les utilisateurs ne peuvent pas modifier son contenu. Réessayez plus tard ou contactez votre administrateur à {{adminEmail}} pour plus de détails."
+      },
+      "createCalendar": {
+        "createButton": "Créer un nouveau calendrier",
+        "modalTitle": "Créer un calendrier",
+        "contentLanguage": "Langues",
+        "name": "Nom",
+        "namePlaceholder": "Entrez le nom du calendrier",
+        "namePlaceholderWhenNoLanguage": "Sélectionnez d'abord les langues",
+        "contact": "Contact",
+        "timezone": "Fuseau horaire",
+        "dateFormat": "Format de la date",
+        "eventTemplate": "Modèle d'événement",
+        "searchResultTemplate": "Modèle de résultats de recherche",
+        "cancel": "Annuler",
+        "create": "Créer",
+        "success": "Calendrier créé avec succès",
+        "duplicate": "Un calendrier avec ce nom existe déjà"
       }
     },
     "topNavigation": {

--- a/src/services/calendar.js
+++ b/src/services/calendar.js
@@ -30,6 +30,13 @@ export const calendarApi = createApi({
         },
       }),
     }),
+    addCalendar: builder.mutation({
+      query: ({ data }) => ({
+        url: `calendars`,
+        method: 'POST',
+        body: data,
+      }),
+    }),
   }),
 });
 
@@ -38,4 +45,5 @@ export const {
   useLazyGetCalendarQuery,
   useLazyGetAllCalendarsQuery,
   useUpdateCalendarMutation,
+  useAddCalendarMutation,
 } = calendarApi;


### PR DESCRIPTION
## Summary

Adds a **super-admin-only flow to create a calendar directly from the calendar dropdown**.

### Changes

* Added `addCalendar` POST `/calendars` mutation and `useAddCalendarMutation` in `src/services/calendar.js`.
* Exported `dateFormats` from `src/constants/calendarSettingsForm.js`.
* Added new `CreateCalendar` modal:

  * Uses Ant Design `Form` and `Form.useWatch` for `contentLanguage`.
  * Supports multilingual calendar names through `CreateMultiLingualFormItems`.
  * Supports optional:

    * Contact
    * Timezone
    * Date format display
    * Widget settings
  * Calls `addCalendar().unwrap()` on submit.
  * Handles successful `202` responses by:

    * Showing a success toast.
    * Setting the newly created calendar as selected.
    * Updating the recent calendar for the user.
    * Persisting the calendar in `sessionStorage`.
    * Redirecting to the newly created calendar.
  * Handles `409` responses with a warning message.
  * Prevents submission when form validation fails.
* Updated the calendar dropdown:

  * Added `createModalOpen` state.
  * Added a **Create Calendar** footer action visible to super admins.
  * Renders the `CreateCalendar` modal.
* Added styles for the calendar dropdown footer and Create Calendar modal.
* Added English and French translations under `dashboard.calendar.createCalendar.*`.
* Updated `MultilingualInput` to safely handle missing `useOutletContext` header context.

### User Flow

1. A super admin opens the calendar dropdown.
2. Selects **Create Calendar**.
3. Enters the required calendar name and optional settings.
4. Submits the form.
5. On successful creation, the new calendar is selected and the user is redirected to it.

### Error Handling

* **Validation errors:** Submission is blocked until required fields are valid.
* **409 Conflict:** Displays a warning message when the calendar cannot be created due to a conflict.
* **Successful creation:** Handles the `202` response and redirects to the newly created calendar.
